### PR TITLE
refactor(MS): display exact mass instead of theoretical mass

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -56,7 +56,7 @@ const SpectraEditor = _ref => {
     molSvg,
     editorOnly,
     descriptions,
-    theoryMass,
+    exactMass,
     canChangeDescription,
     onDescriptionChanged,
     multiEntities,
@@ -83,7 +83,7 @@ const SpectraEditor = _ref => {
     molSvg: molSvg,
     multiMolSvgs: multiMolSvgs,
     editorOnly: editorOnly,
-    theoryMass: theoryMass,
+    exactMass: exactMass,
     canChangeDescription: canChangeDescription,
     onDescriptionChanged: onDescriptionChanged
   })));
@@ -106,7 +106,7 @@ SpectraEditor.propTypes = {
   canChangeDescription: _propTypes.default.bool,
   onDescriptionChanged: _propTypes.default.func,
   userManualLink: _propTypes.default.object,
-  theoryMass: _propTypes.default.string
+  exactMass: _propTypes.default.string
 };
 SpectraEditor.defaultProps = {
   others: {
@@ -122,7 +122,7 @@ SpectraEditor.defaultProps = {
   operations: [],
   descriptions: [],
   molSvg: '',
-  theoryMass: '',
+  exactMass: '',
   multiMolSvgs: [],
   editorOnly: false,
   canChangeDescription: false,

--- a/dist/components/multi_jcamps_viewer.js
+++ b/dist/components/multi_jcamps_viewer.js
@@ -63,7 +63,7 @@ class MultiJcampsViewer extends _react.default.Component {
       entities,
       userManualLink,
       molSvg,
-      theoryMass,
+      exactMass,
       layoutSt,
       integrationSt
     } = this.props;
@@ -112,7 +112,7 @@ class MultiJcampsViewer extends _react.default.Component {
       userManualLink: userManualLink,
       feature: feature,
       molSvg: molSvg,
-      theoryMass: theoryMass,
+      exactMass: exactMass,
       subLayoutsInfo: seperatedSubLayouts,
       integration: currentIntegration,
       descriptions: "",
@@ -152,7 +152,7 @@ MultiJcampsViewer.propTypes = {
   userManualLink: _propTypes.default.object,
   entities: _propTypes.default.array,
   layoutSt: _propTypes.default.string.isRequired,
-  theoryMass: _propTypes.default.string,
+  exactMass: _propTypes.default.string,
   integrationSt: _propTypes.default.object.isRequired
 };
 MultiJcampsViewer.defaultProps = {

--- a/dist/components/panel/index.js
+++ b/dist/components/panel/index.js
@@ -85,7 +85,7 @@ class PanelViewer extends _react.default.Component {
       curveSt,
       userManualLink,
       subLayoutsInfo,
-      theoryMass
+      exactMass
     } = this.props;
     const onExapndInfo = () => this.onExapnd('info');
     const onExapndPeak = () => this.onExapnd('peak');
@@ -115,7 +115,7 @@ class PanelViewer extends _react.default.Component {
       editorOnly: editorOnly,
       expand: expand === 'info',
       molSvg: molSvg,
-      theoryMass: theoryMass,
+      exactMass: exactMass,
       onExapnd: onExapndInfo,
       descriptions: descriptions,
       canChangeDescription: canChangeDescription,
@@ -159,7 +159,7 @@ PanelViewer.propTypes = {
   userManualLink: _propTypes.default.object,
   curveSt: _propTypes.default.object.isRequired,
   subLayoutsInfo: _propTypes.default.object,
-  theoryMass: _propTypes.default.string
+  exactMass: _propTypes.default.string
 };
 var _default = exports.default = (0, _reactRedux.connect)(
 // eslint-disable-line

--- a/dist/components/panel/info.js
+++ b/dist/components/panel/info.js
@@ -231,7 +231,7 @@ const InfoPanel = _ref3 => {
     simulationSt,
     shiftSt,
     curveSt,
-    theoryMass,
+    exactMass,
     onExapnd,
     canChangeDescription,
     onDescriptionChanged,
@@ -313,13 +313,13 @@ const InfoPanel = _ref3 => {
     className: (0, _classnames.default)(classes.tTxt, classes.tHead, 'txt-sv-panel-txt')
   }, "Solv : "), /*#__PURE__*/_react.default.createElement("span", {
     className: (0, _classnames.default)(classes.tTxt, 'txt-sv-panel-txt')
-  }, showSolvName)) : null, _format.default.isMsLayout(layoutSt) && theoryMass ? /*#__PURE__*/_react.default.createElement("div", {
+  }, showSolvName)) : null, _format.default.isMsLayout(layoutSt) && exactMass ? /*#__PURE__*/_react.default.createElement("div", {
     className: (0, _classnames.default)(classes.rowRoot, classes.rowOdd)
   }, /*#__PURE__*/_react.default.createElement("span", {
     className: (0, _classnames.default)(classes.tTxt, classes.tHead, 'txt-sv-panel-txt')
-  }, "Theoretical mass: "), /*#__PURE__*/_react.default.createElement("span", {
+  }, "Exact mass: "), /*#__PURE__*/_react.default.createElement("span", {
     className: (0, _classnames.default)(classes.tTxt, 'txt-sv-panel-txt')
-  }, `${parseFloat(theoryMass).toFixed(6)} g/mol`)) : null, /*#__PURE__*/_react.default.createElement(SECData, {
+  }, `${parseFloat(exactMass).toFixed(6)} g/mol`)) : null, /*#__PURE__*/_react.default.createElement(SECData, {
     classes: classes,
     layout: layoutSt,
     detector: selectedDetector,
@@ -383,7 +383,7 @@ InfoPanel.propTypes = {
   onExapnd: _propTypes.default.func.isRequired,
   canChangeDescription: _propTypes.default.bool.isRequired,
   onDescriptionChanged: _propTypes.default.func,
-  theoryMass: _propTypes.default.string,
+  exactMass: _propTypes.default.string,
   detectorSt: _propTypes.default.object.isRequired,
   metaSt: _propTypes.default.object.isRequired,
   updateDSCMetaDataAct: _propTypes.default.func.isRequired

--- a/src/app.js
+++ b/src/app.js
@@ -33,7 +33,7 @@ const ensureQuillDelta = (descs) => {
 // - - - React - - -
 const SpectraEditor = ({
   entity, others, cLabel, xLabel, yLabel,
-  operations, forecast, molSvg, editorOnly, descriptions, theoryMass,
+  operations, forecast, molSvg, editorOnly, descriptions, exactMass,
   canChangeDescription, onDescriptionChanged,
   multiEntities, multiMolSvgs, entityFileNames, userManualLink,
 }) => (
@@ -54,7 +54,7 @@ const SpectraEditor = ({
         molSvg={molSvg}
         multiMolSvgs={multiMolSvgs}
         editorOnly={editorOnly}
-        theoryMass={theoryMass}
+        exactMass={exactMass}
         canChangeDescription={canChangeDescription}
         onDescriptionChanged={onDescriptionChanged}
       />
@@ -82,7 +82,7 @@ SpectraEditor.propTypes = {
   canChangeDescription: PropTypes.bool,
   onDescriptionChanged: PropTypes.func,
   userManualLink: PropTypes.object,
-  theoryMass: PropTypes.string,
+  exactMass: PropTypes.string,
 };
 
 SpectraEditor.defaultProps = {
@@ -96,7 +96,7 @@ SpectraEditor.defaultProps = {
   operations: [],
   descriptions: [],
   molSvg: '',
-  theoryMass: '',
+  exactMass: '',
   multiMolSvgs: [],
   editorOnly: false,
   canChangeDescription: false,

--- a/src/components/multi_jcamps_viewer.js
+++ b/src/components/multi_jcamps_viewer.js
@@ -54,7 +54,7 @@ class MultiJcampsViewer extends React.Component { // eslint-disable-line
   render() {
     const {
       classes, curveSt, operations, entityFileNames,
-      entities, userManualLink, molSvg, theoryMass, layoutSt,
+      entities, userManualLink, molSvg, exactMass, layoutSt,
       integrationSt,
     } = this.props;
     if (!entities || entities.length === 0) return (<div />);
@@ -93,7 +93,7 @@ class MultiJcampsViewer extends React.Component { // eslint-disable-line
                 userManualLink={userManualLink}
                 feature={feature}
                 molSvg={molSvg}
-                theoryMass={theoryMass}
+                exactMass={exactMass}
                 subLayoutsInfo={seperatedSubLayouts}
                 integration={currentIntegration}
                 descriptions=""
@@ -143,7 +143,7 @@ MultiJcampsViewer.propTypes = {
   userManualLink: PropTypes.object,
   entities: PropTypes.array,
   layoutSt: PropTypes.string.isRequired,
-  theoryMass: PropTypes.string,
+  exactMass: PropTypes.string,
   integrationSt: PropTypes.object.isRequired,
 };
 

--- a/src/components/panel/index.js
+++ b/src/components/panel/index.js
@@ -72,7 +72,7 @@ class PanelViewer extends React.Component {
     const {
       classes, feature, integration, editorOnly, molSvg, descriptions, layoutSt,
       canChangeDescription, jcampIdx, entityFileNames, curveSt, userManualLink,
-      subLayoutsInfo, theoryMass,
+      subLayoutsInfo, exactMass,
     } = this.props;
     const onExapndInfo = () => this.onExapnd('info');
     const onExapndPeak = () => this.onExapnd('peak');
@@ -97,7 +97,7 @@ class PanelViewer extends React.Component {
               editorOnly={editorOnly}
               expand={expand === 'info'}
               molSvg={molSvg}
-              theoryMass={theoryMass}
+              exactMass={exactMass}
               onExapnd={onExapndInfo}
               descriptions={descriptions}
               canChangeDescription={canChangeDescription}
@@ -140,7 +140,7 @@ PanelViewer.propTypes = {
   userManualLink: PropTypes.object,
   curveSt: PropTypes.object.isRequired,
   subLayoutsInfo: PropTypes.object,
-  theoryMass: PropTypes.string,
+  exactMass: PropTypes.string,
 };
 
 export default connect( // eslint-disable-line

--- a/src/components/panel/info.js
+++ b/src/components/panel/info.js
@@ -196,7 +196,7 @@ DSCData.propTypes = {
 
 const InfoPanel = ({
   classes, expand, feature, integration, editorOnly, molSvg, descriptions,
-  layoutSt, simulationSt, shiftSt, curveSt, theoryMass,
+  layoutSt, simulationSt, shiftSt, curveSt, exactMass,
   onExapnd, canChangeDescription, onDescriptionChanged, detectorSt,
   metaSt, updateDSCMetaDataAct,
 }) => {
@@ -279,11 +279,11 @@ const InfoPanel = ({
             : null
         }
         {
-          Format.isMsLayout(layoutSt) && theoryMass
+          Format.isMsLayout(layoutSt) && exactMass
             ? (
               <div className={classNames(classes.rowRoot, classes.rowOdd)}>
-                <span className={classNames(classes.tTxt, classes.tHead, 'txt-sv-panel-txt')}>Theoretical mass: </span>
-                <span className={classNames(classes.tTxt, 'txt-sv-panel-txt')}>{`${parseFloat(theoryMass).toFixed(6)} g/mol`}</span>
+                <span className={classNames(classes.tTxt, classes.tHead, 'txt-sv-panel-txt')}>Exact mass: </span>
+                <span className={classNames(classes.tTxt, 'txt-sv-panel-txt')}>{`${parseFloat(exactMass).toFixed(6)} g/mol`}</span>
               </div>
             )
             : null
@@ -387,7 +387,7 @@ InfoPanel.propTypes = {
   onExapnd: PropTypes.func.isRequired,
   canChangeDescription: PropTypes.bool.isRequired,
   onDescriptionChanged: PropTypes.func,
-  theoryMass: PropTypes.string,
+  exactMass: PropTypes.string,
   detectorSt: PropTypes.object.isRequired,
   metaSt: PropTypes.object.isRequired,
   updateDSCMetaDataAct: PropTypes.func.isRequired,

--- a/src/index.js
+++ b/src/index.js
@@ -686,7 +686,7 @@ class DemoWriteIr extends React.Component {
           canChangeDescription={true}
           onDescriptionChanged={this.onDescriptionChanged}
           molSvg={molSvg}
-          theoryMass={'123.0'}
+          exactMass={'123.0'}
           userManualLink={{cv: "https://www.chemotion.net/chemotionsaurus/docs/eln/chemspectra/cvanalysis"}}
           forecast={forecast}
           operations={operations}

--- a/src/layer_init.js
+++ b/src/layer_init.js
@@ -108,7 +108,7 @@ class LayerInit extends React.Component {
   render() {
     const {
       entity, cLabel, xLabel, yLabel, forecast, operations,
-      descriptions, molSvg, editorOnly, theoryMass,
+      descriptions, molSvg, editorOnly, exactMass,
       canChangeDescription, onDescriptionChanged,
       multiEntities, entityFileNames, userManualLink,
     } = this.props;
@@ -126,7 +126,7 @@ class LayerInit extends React.Component {
           entityFileNames={entityFileNames}
           userManualLink={userManualLink}
           molSvg={molSvg}
-          theoryMass={theoryMass}
+          exactMass={exactMass}
           operations={operations}
         />
       );
@@ -137,7 +137,7 @@ class LayerInit extends React.Component {
           entityFileNames={entityFileNames}
           userManualLink={userManualLink}
           molSvg={molSvg}
-          theoryMass={theoryMass}
+          exactMass={exactMass}
           operations={operations}
         />
       );
@@ -154,7 +154,7 @@ class LayerInit extends React.Component {
         descriptions={descriptions}
         molSvg={molSvg}
         editorOnly={editorOnly}
-        theoryMass={theoryMass}
+        exactMass={exactMass}
         canChangeDescription={canChangeDescription}
         onDescriptionChanged={onDescriptionChanged}
       />
@@ -191,7 +191,7 @@ LayerInit.propTypes = {
   yLabel: PropTypes.string.isRequired,
   molSvg: PropTypes.string.isRequired,
   editorOnly: PropTypes.bool.isRequired,
-  theoryMass: PropTypes.string.isRequired,
+  exactMass: PropTypes.string.isRequired,
   forecast: PropTypes.object.isRequired,
   operations: PropTypes.array.isRequired,
   descriptions: PropTypes.array.isRequired,

--- a/src/layer_prism.js
+++ b/src/layer_prism.js
@@ -20,7 +20,7 @@ const styles = () => ({
 
 const LayerPrism = ({
   entity, cLabel, xLabel, yLabel, forecast, operations,
-  descriptions, molSvg, editorOnly, theoryMass,
+  descriptions, molSvg, editorOnly, exactMass,
   thresSt, scanSt, uiSt,
   canChangeDescription, onDescriptionChanged,
 }) => {
@@ -87,7 +87,7 @@ const LayerPrism = ({
               integration={integration}
               editorOnly={editorOnly}
               molSvg={molSvg}
-              theoryMass={theoryMass}
+              exactMass={exactMass}
               descriptions={descriptions}
               canChangeDescription={canChangeDescription}
               onDescriptionChanged={onDescriptionChanged}
@@ -119,7 +119,7 @@ LayerPrism.propTypes = {
   yLabel: PropTypes.string.isRequired,
   molSvg: PropTypes.string.isRequired,
   editorOnly: PropTypes.bool.isRequired,
-  theoryMass: PropTypes.string,
+  exactMass: PropTypes.string,
   forecast: PropTypes.object.isRequired,
   operations: PropTypes.array.isRequired,
   descriptions: PropTypes.array.isRequired,


### PR DESCRIPTION
This PR addresses [issue #2260](https://github.com/ComPlat/chemotion_ELN/issues/2260) from the Chemotion ELN repository. 

Currently, the Spectra Editor UI for mass spec displays the "theoretical mass" on the right-hand side. However, the value displayed should instead represent the "exact mass" from the sample.

To align the codebase with this requirement, all occurrences of the variable theoryMass have been renamed to exactMass.