### PR TITLE
MS: hover labels use toolbar decimal setting

### DIFF
--- a/src/components/d3_rect/index.js
+++ b/src/components/d3_rect/index.js
@@ -34,7 +34,7 @@ class ViewerRect extends React.Component {
   componentDidMount() {
     const {
       seed, peak, cLabel, xLabel, yLabel, feature,
-      tTrEndPts, tSfPeaks, isHidden,
+      tTrEndPts, tSfPeaks, isHidden, decimalSt,
       sweepExtentSt, isUiAddIntgSt, isUiNoBrushSt,
       resetAllAct,
     } = this.props;
@@ -50,6 +50,7 @@ class ViewerRect extends React.Component {
       filterPeak,
       tTrEndPts,
       tSfPeaks,
+      decimal: decimalSt,
       sweepExtentSt,
       isUiAddIntgSt,
       isUiNoBrushSt,
@@ -61,7 +62,7 @@ class ViewerRect extends React.Component {
   componentDidUpdate(prevProps) {
     const {
       seed, peak,
-      tTrEndPts, tSfPeaks, isHidden,
+      tTrEndPts, tSfPeaks, isHidden, decimalSt,
       sweepExtentSt, isUiAddIntgSt, isUiNoBrushSt,
     } = this.props;
     this.normChange(prevProps);
@@ -74,6 +75,7 @@ class ViewerRect extends React.Component {
       filterPeak,
       tTrEndPts,
       tSfPeaks,
+      decimal: decimalSt,
       sweepExtentSt,
       isUiAddIntgSt,
       isUiNoBrushSt,
@@ -104,6 +106,7 @@ const mapStateToProps = (state, props) => (
   {
     seed: Topic2Seed(state, props),
     peak: Feature2Peak(state, props),
+    decimalSt: state.submit.decimal,
     tTrEndPts: ToThresEndPts(state, props),
     tSfPeaks: ToShiftPeaks(state, props),
     sweepExtentSt: state.ui.sweepExtent,
@@ -124,6 +127,7 @@ const mapDispatchToProps = (dispatch) => (
 ViewerRect.propTypes = {
   seed: PropTypes.array.isRequired,
   peak: PropTypes.array.isRequired,
+  decimalSt: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   cLabel: PropTypes.string.isRequired,
   xLabel: PropTypes.string.isRequired,
   yLabel: PropTypes.string.isRequired,

--- a/src/components/d3_rect/rect_focus.js
+++ b/src/components/d3_rect/rect_focus.js
@@ -52,7 +52,7 @@ class RectFocus {
     this.factor = 0.125;
     this.currentExtent = null;
     this.layout = LIST_LAYOUT.MS;
-    this.decimal = 2;
+    this.decimal = 3;
 
     this.setTip = this.setTip.bind(this);
     this.setDataParams = this.setDataParams.bind(this);

--- a/src/components/d3_rect/rect_focus.js
+++ b/src/components/d3_rect/rect_focus.js
@@ -9,6 +9,7 @@ import {
 import { TfRescale, MountCompass } from '../../helpers/compass';
 import { PksEdit } from '../../helpers/converter';
 import { LIST_LAYOUT } from '../../constants/list_layout';
+import Format from '../../helpers/format';
 
 const d3 = require('d3');
 
@@ -51,6 +52,7 @@ class RectFocus {
     this.factor = 0.125;
     this.currentExtent = null;
     this.layout = LIST_LAYOUT.MS;
+    this.decimal = 2;
 
     this.setTip = this.setTip.bind(this);
     this.setDataParams = this.setDataParams.bind(this);
@@ -69,11 +71,14 @@ class RectFocus {
     this.root.call(this.tip);
   }
 
-  setDataParams(data, peaks, tTrEndPts, tSfPeaks) {
+  setDataParams(data, peaks, tTrEndPts, tSfPeaks, decimal) {
     this.data = [...data];
     this.dataPks = [...peaks];
     this.tTrEndPts = tTrEndPts;
     this.tSfPeaks = tSfPeaks;
+    if (decimal !== undefined) {
+      this.decimal = Format.clampDecimalPlaces(decimal);
+    }
   }
 
   updatePathCall(xt, yt) {
@@ -148,7 +153,9 @@ class RectFocus {
           .attr('stroke-opacity', '1.0');
         d3.select(`#bpt${Math.round(1000 * d.x)}`)
           .style('fill', 'blue');
-        const tipParams = { d, layout: this.layout };
+        const tipParams = {
+          d, layout: this.layout, xDigits: this.decimal,
+        };
         this.tip.show(tipParams, event.target);
       })
       .on('mouseout', (event, d) => {
@@ -156,7 +163,9 @@ class RectFocus {
           .attr('stroke-opacity', '1.0');
         d3.select(`#bpt${Math.round(1000 * d.x)}`)
           .style('fill', 'red');
-        const tipParams = { d, layout: this.layout };
+        const tipParams = {
+          d, layout: this.layout, xDigits: this.decimal,
+        };
         this.tip.hide(tipParams, event.target);
       });
   }
@@ -192,7 +201,7 @@ class RectFocus {
   }
 
   create({
-    filterSeed, filterPeak, tTrEndPts, tSfPeaks,
+    filterSeed, filterPeak, tTrEndPts, tSfPeaks, decimal,
     sweepExtentSt, isUiAddIntgSt, isUiNoBrushSt,
   }) {
     this.svg = d3.select('.d3Svg');
@@ -201,7 +210,7 @@ class RectFocus {
 
     this.root = d3.select(this.rootKlass).selectAll('.focus-main');
     this.setTip();
-    this.setDataParams(filterSeed, filterPeak, tTrEndPts, tSfPeaks);
+    this.setDataParams(filterSeed, filterPeak, tTrEndPts, tSfPeaks, decimal);
     MountCompass(this);
 
     this.axis = MountAxis(this);
@@ -222,11 +231,11 @@ class RectFocus {
   }
 
   update({
-    filterSeed, filterPeak, tTrEndPts, tSfPeaks,
+    filterSeed, filterPeak, tTrEndPts, tSfPeaks, decimal,
     sweepExtentSt, isUiAddIntgSt, isUiNoBrushSt,
   }) {
     this.root = d3.select(this.rootKlass).selectAll('.focus-main');
-    this.setDataParams(filterSeed, filterPeak, tTrEndPts, tSfPeaks);
+    this.setDataParams(filterSeed, filterPeak, tTrEndPts, tSfPeaks, decimal);
 
     if (this.data && this.data.length > 0) {
       this.setConfig(sweepExtentSt);

--- a/src/helpers/compass.js
+++ b/src/helpers/compass.js
@@ -103,9 +103,12 @@ const MouseMove = (event, focus) => {
           .attr('transform', `translate(${tx},${10})`)
           .text(`X: ${pt.x.toFixed(3)}, Y: ${pt.y.toFixed(3)}`);
       } else {
+        const xPrecision = Format.isMsLayout(layout)
+          ? Format.clampDecimalPlaces(focus.decimal)
+          : 3;
         focus.root.select('.cursor-txt')
           .attr('transform', `translate(${tx},${10})`)
-          .text(pt.x.toFixed(3));
+          .text(pt.x.toFixed(xPrecision));
         if (freq) {
           focus.root.select('.cursor-txt-hz')
             .attr('transform', `translate(${tx},${20})`)

--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -39,6 +39,13 @@ const fixDigit = (input, precision) => {
   return output.toFixed(precision);
 };
 
+/** Integer 0–20 for toFixed; invalid input uses fallback (e.g. toolbar decimal). */
+const clampDecimalPlaces = (value, fallback = 2) => {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, Math.min(20, Math.trunc(n)));
+};
+
 const buildData = (entity) => {
   if (!entity) return { isExist: false };
   const sp = entity && entity.spectrum;
@@ -567,6 +574,7 @@ const Format = {
   isEmWaveLayout,
   isGCLayout,
   fixDigit,
+  clampDecimalPlaces,
   formatPeaksByPrediction,
   formatedMS,
   formatedEm,

--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -39,7 +39,10 @@ const fixDigit = (input, precision) => {
   return output.toFixed(precision);
 };
 
-/** Integer 0–20 for toFixed; invalid input uses fallback (defaults to 3 to preserve legacy precision). */
+/**
+ * Integer 0–20 for toFixed; invalid input uses fallback.
+ * Default 3 preserves legacy cursor precision.
+ */
 const clampDecimalPlaces = (value, fallback = 3) => {
   const n = Number(value);
   if (!Number.isFinite(n)) return fallback;

--- a/src/helpers/format.js
+++ b/src/helpers/format.js
@@ -39,8 +39,8 @@ const fixDigit = (input, precision) => {
   return output.toFixed(precision);
 };
 
-/** Integer 0–20 for toFixed; invalid input uses fallback (e.g. toolbar decimal). */
-const clampDecimalPlaces = (value, fallback = 2) => {
+/** Integer 0–20 for toFixed; invalid input uses fallback (defaults to 3 to preserve legacy precision). */
+const clampDecimalPlaces = (value, fallback = 3) => {
   const n = Number(value);
   if (!Number.isFinite(n)) return fallback;
   return Math.max(0, Math.min(20, Math.trunc(n)));

--- a/src/helpers/init.js
+++ b/src/helpers/init.js
@@ -57,11 +57,20 @@ const tpDiv = (d, digits, yFactor = 1) => (
   `
 );
 
+const peakTipHtml = ({
+  d, layout, yFactor, xDigits,
+}) => {
+  const digits = xDigits != null && xDigits !== ''
+    ? FN.clampDecimalPlaces(xDigits, FN.spectraDigit(layout))
+    : FN.spectraDigit(layout);
+  return tpDiv(d, digits, yFactor || 1);
+};
+
 const InitTip = () => {
   d3.select('.peak-tp').remove();
   const tip = d3Tip()
     .attr('class', 'd3-tip')
-    .html(({ d, layout, yFactor }) => tpDiv(d, FN.spectraDigit(layout), yFactor || 1));
+    .html(peakTipHtml);
   return tip;
 };
 


### PR DESCRIPTION
# Description
Fixes the mismatch where MS hover always showed three decimal places while the toolbar “Decimal” control allowed 0–4.

# Changes

Pass submit.decimal from Redux into the MS rect viewer (RectFocus).
Compass cursor label: for MS only, format m/z with the same decimal count as the toolbar (other layouts unchanged).
Peak tooltip on MS bars: optional xDigits so x in the tip matches that setting; add Format.clampDecimalPlaces for safe parsing.

Closes [#3026](https://github.com/ComPlat/chemotion_ELN/issues/3026)