### PR TITLE
fix: ms exact mass (M+)

### DIFF
--- a/src/__tests__/units/components/panel/info.test.js
+++ b/src/__tests__/units/components/panel/info.test.js
@@ -78,4 +78,44 @@ describe("<InfoPanel />", () => {
     const {queryByTestId} = render(renderer);
     expect(queryByTestId('PanelInfo')).toBeInTheDocument();
   });
+
+  test('Render M+ exact mass for MS layout', () => {
+    const msStore = mockStore({
+      curve: {
+        listCurves: [{feature: {}}],
+        curveIdx: 0
+      },
+      layout: LIST_LAYOUT.MS,
+      shift: {
+        shifts: [],
+      },
+      simulation: [],
+      detector: {
+        curves: [
+          {
+            curveIdx: 0,
+            selectedDetector: { name: 'Refractive index', label: 'RI' },
+          },
+        ],
+      },
+      meta: {}
+    });
+
+    const renderer =
+      <AppWrapper store={msStore}>
+        <ThemeProvider theme={theme}>
+          <InfoPanel
+            expand={false}
+            onExapnd={() => {}}
+            feature={feature}
+            exactMass="121.0653"
+          />
+        </ThemeProvider>
+      </AppWrapper>
+    ;
+
+    render(renderer);
+
+    expect(screen.getByText('121.064751 g/mol')).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/units/components/panel/info.test.js
+++ b/src/__tests__/units/components/panel/info.test.js
@@ -105,7 +105,7 @@ describe("<InfoPanel />", () => {
       <AppWrapper store={msStore}>
         <ThemeProvider theme={theme}>
           <InfoPanel
-            expand={false}
+            expand
             onExapnd={() => {}}
             feature={feature}
             exactMass="121.0653"

--- a/src/components/panel/info.js
+++ b/src/components/panel/info.js
@@ -17,6 +17,8 @@ import { withStyles } from '@mui/styles';
 import Format from '../../helpers/format';
 import { updateDSCMetaData } from '../../actions/meta';
 
+const ELECTRON_MASS = 0.000548579909065;
+
 const styles = () => ({
   chip: {
     margin: '1px 0 1px 0',
@@ -118,6 +120,13 @@ const normalizeQuillValue = (val) => {
   if (!val) return '';
   if (val === '<p><br></p>' || val === '<p></p>') return '';
   return val;
+};
+
+const formatMsExactMass = (exactMass) => {
+  const neutralMass = parseFloat(exactMass);
+  if (Number.isNaN(neutralMass)) return null;
+
+  return (neutralMass - ELECTRON_MASS).toFixed(6);
 };
 
 const chemSubStyle = {
@@ -268,6 +277,9 @@ const InfoPanel = ({
   metaSt, updateDSCMetaDataAct,
 }) => {
   if (!feature) return null;
+  const msExactMass = Format.isMsLayout(layoutSt) && exactMass
+    ? formatMsExactMass(exactMass)
+    : null;
   const {
     title, observeFrequency, solventName, secData,
   } = feature;
@@ -350,11 +362,11 @@ const InfoPanel = ({
             : null
         }
         {
-          Format.isMsLayout(layoutSt) && exactMass
+          msExactMass
             ? (
               <div className={classNames(classes.rowRoot, classes.rowOdd)}>
-                <span className={classNames(classes.tTxt, classes.tHead, 'txt-sv-panel-txt')}>Exact mass: </span>
-                <span className={classNames(classes.tTxt, 'txt-sv-panel-txt')}>{`${parseFloat(exactMass).toFixed(6)} g/mol`}</span>
+                <span className={classNames(classes.tTxt, classes.tHead, 'txt-sv-panel-txt')}>Exact mass (M+): </span>
+                <span className={classNames(classes.tTxt, 'txt-sv-panel-txt')}>{`${msExactMass} g/mol`}</span>
               </div>
             )
             : null


### PR DESCRIPTION
## Summary
- show `Exact mass (M+)` instead of neutral `M` in the MS info panel
- calculate the displayed value by subtracting the electron mass from the exact mass
- add a focused test for the M to M+ conversion

## Test plan
- open an MS spectrum and check that the info panel shows `Exact mass (M+)`
- verify the displayed value is slightly lower than the neutral exact mass
- run the InfoPanel test