### PR TITLE
fix(cv): apply CV current-density factor once on submit/export (B5 remainder, for #232)

### DIFF
--- a/src/__tests__/units/components/cmd_bar/r05_submit_btn.test.js
+++ b/src/__tests__/units/components/cmd_bar/r05_submit_btn.test.js
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import BtnSubmit from '../../../../components/cmd_bar/r05_submit_btn';
+import BtnSubmit, { computeCvYScaleFactor } from '../../../../components/cmd_bar/r05_submit_btn';
 import Format from '../../../../helpers/format';
 
 jest.mock('../../../../helpers/extractPeaksEdit', () => ({
@@ -184,6 +184,41 @@ describe('<BtnSubmit payload contract />', () => {
       expect(entry).not.toHaveProperty('lcms_integrals');
       expect(entry).not.toHaveProperty('lcms_peaks_text');
       expect(payload.lcms_peaks).toEqual([{ peakMock: true }]);
+    });
+  });
+
+  // Regression for review finding RR-1 (B5 remainder): the CV current-density factor
+  // used on submit/export must match the chart (multi_focus.computeYTransformFactor)
+  // and panel — i.e. one conversion to A/cm², not a double /100 for mm².
+  describe('computeCvYScaleFactor — CV current-density factor (RR-1 / B5)', () => {
+    const feature = { yUnit: 'A' };
+
+    it('returns 1.0 when current density is off', () => {
+      expect(computeCvYScaleFactor(feature, { useCurrentDensity: false })).toEqual(1.0);
+    });
+
+    it('treats 100 mm² the same as 1 cm² (no double /100)', () => {
+      const fMm2 = computeCvYScaleFactor(feature, {
+        useCurrentDensity: true, areaValue: 100, areaUnit: 'mm²',
+      });
+      const fCm2 = computeCvYScaleFactor(feature, {
+        useCurrentDensity: true, areaValue: 1, areaUnit: 'cm²',
+      });
+      expect(fMm2).toBeCloseTo(fCm2);
+      expect(fMm2).toBeCloseTo(1.0); // pre-fix this was 0.01 (100x too small)
+    });
+
+    it('gives A/cm² for a mm² area (factor = 100 / area_mm²)', () => {
+      // 50 mm² == 0.5 cm² → factor 1/0.5 = 2
+      expect(computeCvYScaleFactor(feature, {
+        useCurrentDensity: true, areaValue: 50, areaUnit: 'mm²',
+      })).toBeCloseTo(2.0);
+    });
+
+    it('scales by 1000 for mA while keeping the area conversion', () => {
+      expect(computeCvYScaleFactor({ yUnit: 'mA' }, {
+        useCurrentDensity: true, areaValue: 100, areaUnit: 'mm²',
+      })).toBeCloseTo(1000.0);
     });
   });
 });

--- a/src/components/cmd_bar/r05_submit_btn.js
+++ b/src/components/cmd_bar/r05_submit_btn.js
@@ -59,19 +59,17 @@ const buildCvAxisYLabel = (yLabel, cyclicvoltaSt) => {
   return `Current in ${baseUnit}`;
 };
 
-const computeCvYScaleFactor = (feature, cyclicvoltaSt) => {
+export const computeCvYScaleFactor = (feature, cyclicvoltaSt) => {
   if (!cyclicvoltaSt?.useCurrentDensity) return 1.0;
   const rawArea = (cyclicvoltaSt.areaValue === '' ? 1.0 : cyclicvoltaSt.areaValue) || 1.0;
   const areaUnit = cyclicvoltaSt.areaUnit || 'cm²';
   const safeArea = rawArea > 0 ? rawArea : 1.0;
+  // areaInCm2 already converts mm² → cm², so factor is A/cm². Do NOT divide by 100 again.
   const areaInCm2 = areaUnit === 'mm²' ? (safeArea / 100.0) : safeArea;
   let factor = 1.0 / areaInCm2;
   const baseY = feature && feature.yUnit ? String(feature.yUnit) : 'A';
   if (/mA/i.test(baseY)) {
     factor *= 1000.0;
-  }
-  if (areaUnit === 'mm²') {
-    factor /= 100.0;
   }
   return factor;
 };


### PR DESCRIPTION
## What

Fixes a residual **B5** bug found while re-reviewing #232 at `5854338` (review finding **RR-1**).

`computeCvYScaleFactor` in `r05_submit_btn.js` (the submit/export path) divided the CV current-density factor by 100 **twice** for `areaUnit === 'mm²'`:

- `areaInCm2 = safeArea / 100` → `factor = 1 / areaInCm2 = 100 / safeArea` (already correct A/cm²), then
- `if (areaUnit === 'mm²') factor /= 100` → `1 / safeArea` — **100× too small**.

The B5 review fix removed this duplicate division in the **chart** (`multi_focus.computeYTransformFactor`) and the **panel** (`cyclic_voltamery_data.formatCurrent`), but the factor is duplicated in **three** places and this third copy was missed. As a result, the CV current-density value written on submit/export was 100× smaller than what the chart and panel now display — persisted/exported data disagreed with the on-screen numbers.

## Change

- Remove the redundant `if (areaUnit === 'mm²') factor /= 100` block so the submit/export factor matches the chart and panel (single mm²→cm² conversion).
- Export `computeCvYScaleFactor` so it is unit-testable.
- Add a regression test asserting **100 mm² ≡ 1 cm²** (same factor), plus mm² A/cm² scaling and the mA ×1000 path.

## Test

`yarn test src/__tests__/units/components/cmd_bar/r05_submit_btn.test.js` — 9 passed (4 new). The `100 mm²` case returns `0.01` on the unfixed code, so the test fails without this change.

## Notes / follow-ups (not in this PR)

- The three current-density factor copies (`multi_focus`, `cyclic_voltamery_data`, `r05_submit_btn`, plus the inverse in `r10_cv_density`) duplicate the same `areaInCm2` math — a shared helper would prevent this class of drift. Left out to keep this fix surgical.
- Other re-review follow-ons against #232 remain open: RR-3 (`Convert2Peak` offset on the recompute fallback), RR-4 (panel density label for non-mm²/cm² units), RR-2/5/6 (`getArea`/`getAbsoluteArea` edge cases), and dispersing `pr232_review_blocking.test.tsx` into the per-subject test files.

refs #232