### PR TITLE
ci: bump GitHub Actions to node24 runtimes

### DIFF
--- a/.github/workflows/e2e_testing.yml
+++ b/.github/workflows/e2e_testing.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           build: npm run --max_old_space_size=12288 build
           start: npm --max_old_space_size=12288 start

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22.17.1
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22.17.1
+          node-version: 22.23.1
           registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn compile

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,6 +9,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22.17.1
+          node-version: 22.23.1
       - run: yarn install --frozen-lockfile
       - run: yarn test

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,8 +6,8 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22.17.1
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## What

Silences the **"Node.js 20 is deprecated"** warning on the Actions runner, and refreshes the pinned Node.

### node24 action runtimes
Three actions still run on the **node20** action runtime, which GitHub is deprecating in favour of **node24**. Bumped each to the major that runs on node24:

| Action | Bump | Workflows |
|---|---|---|
| `actions/checkout` | `v4 → v5` | testing, e2e, publish |
| `actions/setup-node` | `v4 → v5` | testing, publish |
| `cypress-io/github-action` | `v6 → v7` | e2e |

Verified via each `action.yml` that `@v6` Cypress is `using: node20` while `@v7` is `node24`. `cypress-io/github-action@v7.0.0`'s **only** breaking change is that runtime bump, so the `build` / `start` / `browser` inputs are unaffected.

### node-version
`actions/setup-node`'s pinned Node bumped **22.17.1 → 22.23.1** (current latest 22.x) in testing + publish. Node 22 is in Maintenance LTS (supported to 2027-04-30), so this stays on a supported line and picks up security/critical fixes.

## Not changed

- Staying on the **Node 22** line (Maintenance LTS) rather than moving to 24 (Active LTS) — minimal change; can revisit separately.
- No `engines` field in `package.json`, so nothing to change there.

No application behaviour change — CI configuration only.

## Note

This lands on `master`; the warning will persist on CI for branches that haven't picked it up yet (e.g. the in-flight `231-display-lcms-data` stack) until it propagates down.