### PR TITLE
fix(lcms): resolve review regressions B1, B4–B7 on master

### DIFF
--- a/src/__tests__/units/components/cmd_bar/r05_submit_btn.test.js
+++ b/src/__tests__/units/components/cmd_bar/r05_submit_btn.test.js
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import BtnSubmit from '../../../../components/cmd_bar/r05_submit_btn';
+import BtnSubmit, { computeCvYScaleFactor } from '../../../../components/cmd_bar/r05_submit_btn';
 import Format from '../../../../helpers/format';
 
 jest.mock('../../../../helpers/extractPeaksEdit', () => ({
@@ -184,6 +184,41 @@ describe('<BtnSubmit payload contract />', () => {
       expect(entry).not.toHaveProperty('lcms_integrals');
       expect(entry).not.toHaveProperty('lcms_peaks_text');
       expect(payload.lcms_peaks).toEqual([{ peakMock: true }]);
+    });
+  });
+
+  // Regression for review finding RR-1 (B5 remainder): the CV current-density factor
+  // used on submit/export must match the chart (multi_focus.computeYTransformFactor)
+  // and panel — i.e. one conversion to A/cm², not a double /100 for mm².
+  describe('computeCvYScaleFactor — CV current-density factor (RR-1 / B5)', () => {
+    const feature = { yUnit: 'A' };
+
+    it('returns 1.0 when current density is off', () => {
+      expect(computeCvYScaleFactor(feature, { useCurrentDensity: false })).toEqual(1.0);
+    });
+
+    it('treats 100 mm² the same as 1 cm² (no double /100)', () => {
+      const fMm2 = computeCvYScaleFactor(feature, {
+        useCurrentDensity: true, areaValue: 100, areaUnit: 'mm²',
+      });
+      const fCm2 = computeCvYScaleFactor(feature, {
+        useCurrentDensity: true, areaValue: 1, areaUnit: 'cm²',
+      });
+      expect(fMm2).toBeCloseTo(fCm2);
+      expect(fMm2).toBeCloseTo(1.0); // pre-fix this was 0.01 (100x too small)
+    });
+
+    it('gives A/cm² for a mm² area (factor = 100 / area_mm²)', () => {
+      // 50 mm² == 0.5 cm² → factor 1/0.5 = 2
+      expect(computeCvYScaleFactor(feature, {
+        useCurrentDensity: true, areaValue: 50, areaUnit: 'mm²',
+      })).toBeCloseTo(2.0);
+    });
+
+    it('scales by 1000 for mA while keeping the area conversion', () => {
+      expect(computeCvYScaleFactor({ yUnit: 'mA' }, {
+        useCurrentDensity: true, areaValue: 100, areaUnit: 'mm²',
+      })).toBeCloseTo(1000.0);
     });
   });
 });

--- a/src/__tests__/units/components/d3_line_rect.test.js
+++ b/src/__tests__/units/components/d3_line_rect.test.js
@@ -1,5 +1,6 @@
 import { isLcmsMsPageLoading } from '../../../components/d3_line_rect/index';
 import { pickTicIndex } from '../../../components/d3_line_rect/multi_focus';
+import RectFocus from '../../../components/d3_line_rect/rect_focus';
 
 describe('isLcmsMsPageLoading', () => {
   const buildMzEntity = (polarity, pageValues) => ({
@@ -64,5 +65,21 @@ describe('isLcmsMsPageLoading', () => {
     };
 
     expect(isLcmsMsPageLoading([], state)).toEqual(true);
+  });
+});
+
+// Review finding B7 (#232): drawBar reads tTrEndPts[0].y. Clearing the
+// threshold makes convertThresEndPts return [] (see chem.test.tsx) while the
+// MS bars are still present, so drawBar must guard the empty endpoint list
+// instead of crashing.
+describe('RectFocus.drawBar with an empty threshold-endpoint list (B7)', () => {
+  it('does not crash when tTrEndPts is empty but bars exist', () => {
+    const rf = Object.create(RectFocus.prototype);
+    rf.bars = {}; // truthy → passes the `if (!this.bars)` guard
+    rf.scales = { x: (v) => v, y: (v) => v }; // TfRescale reads focus.scales.{x,y}
+    rf.updatePathCall = () => {}; // stub out the d3 path update
+    rf.data = [{ x: 1, y: 2 }]; // bars present
+    rf.tTrEndPts = []; // cleared threshold → empty endpoints
+    expect(() => rf.drawBar()).not.toThrow();
   });
 });

--- a/src/__tests__/units/components/d3_multi/multi_focus.test.js
+++ b/src/__tests__/units/components/d3_multi/multi_focus.test.js
@@ -1,0 +1,30 @@
+import MultiFocus from '../../../../components/d3_multi/multi_focus';
+import { LIST_LAYOUT } from '../../../../constants/list_layout';
+
+// Review finding B5 (#232): the CV current-density factor on the chart
+// (computeYTransformFactor) must convert the electrode area to cm² exactly
+// once. Physically 100 mm² == 1 cm², so the factor for the two must match —
+// double-dividing by 100 for mm² made it 100x too small.
+// (computeYTransformFactor is pure — it ignores `this` — so it is called via
+//  the prototype.)
+describe('MultiFocus.computeYTransformFactor — CV current density (B5)', () => {
+  const compute = (cvSt) => MultiFocus.prototype.computeYTransformFactor.call(
+    {}, LIST_LAYOUT.CYCLIC_VOLTAMMETRY, cvSt, { yUnit: 'A' },
+  );
+
+  it('treats 100 mm² the same as 1 cm²', () => {
+    const fMm2 = compute({ useCurrentDensity: true, areaValue: 100, areaUnit: 'mm²' });
+    const fCm2 = compute({ useCurrentDensity: true, areaValue: 1, areaUnit: 'cm²' });
+    expect(fMm2).toBeCloseTo(fCm2);
+    expect(fMm2).toBeCloseTo(1.0); // double /100 for mm² gives 0.01
+  });
+
+  it('gives A/cm² for a mm² area (factor = 100 / area_mm²)', () => {
+    // 50 mm² == 0.5 cm² → factor 1 / 0.5 = 2
+    expect(compute({ useCurrentDensity: true, areaValue: 50, areaUnit: 'mm²' })).toBeCloseTo(2.0);
+  });
+
+  it('returns 1.0 when current density is off', () => {
+    expect(compute({ useCurrentDensity: false })).toBeCloseTo(1.0);
+  });
+});

--- a/src/__tests__/units/helpers/chem.test.tsx
+++ b/src/__tests__/units/helpers/chem.test.tsx
@@ -3,7 +3,7 @@ import {
   ToFrequency, Convert2Scan, Convert2Thres, GetComparisons, Convert2DValue,
   GetCyclicVoltaRatio, GetCyclicVoltaPeakSeparate, convertTopic,
   Convert2MaxMinPeak, Feature2MaxMinPeak, GetCyclicVoltaShiftOffset, GetCyclicVoltaPreviousShift,
-  buildIntegFeature,
+  buildIntegFeature, convertThresEndPts,
 } from "../../../helpers/chem";
 import nmr1HJcamp from "../../fixtures/nmr1h_jcamp";
 import aifJcamp1 from "../../fixtures/aif_jcamp_1";
@@ -193,6 +193,29 @@ describe('Test for chem helper', () => {
       const offset = 0
       const peaks = Convert2Peak(feature, threshold, offset)
       expect(peaks).toEqual([{x: 2, y: 2}, {x: -2, y: -2}])
+    })
+
+    // Review finding B4 (#232): for an LC/MS feature carrying edited/stored
+    // peaks, Convert2Peak must return those peaks with the offset applied,
+    // rather than recomputing them from the raw data and dropping the offset.
+    it('honours stored LC/MS peaks and applies the offset', () => {
+      const feature = {
+        operation: { layout: 'LC/MS' },
+        data: [{ x: [10, 11, 12], y: [1, 5, 1] }],
+        peaks: [{ x: 5, y: 100 }], // user-edited / stored peaks
+      }
+      const peaks = Convert2Peak(feature, 0, 2)
+      expect(peaks).toEqual([{ x: 3, y: 100 }])
+    })
+  })
+
+  // Review finding B7 (#232) precondition: clearing the threshold input yields
+  // an empty endpoint list (the state that made drawBar crash — the drawBar
+  // guard itself is covered in components/d3_line_rect.test.js).
+  describe('convertThresEndPts', () => {
+    it('returns [] when the threshold is cleared', () => {
+      const feature = { maxY: 100, maxX: 10, minX: 0, data: [{ x: [1, 2], y: [3, 4] }] }
+      expect(convertThresEndPts(feature, '')).toEqual([])
     })
   })
 

--- a/src/__tests__/units/sagas/saga_ui_lcms.test.tsx
+++ b/src/__tests__/units/sagas/saga_ui_lcms.test.tsx
@@ -258,6 +258,33 @@ describe('saga_ui — clickUiTarget LCMS branches', () => {
     expect(value).toBeUndefined();
   });
 
+  // Review finding B1 (#232): on a NON-LCMS layout, PEAK_ADD must still add a
+  // positive edit-peak (EDITPEAK.ADD_POSITIVE). The LCMS-only path must not
+  // swallow peak-add for NMR/IR/MS layouts.
+  it('PEAK_ADD on a non-LCMS layout dispatches EDITPEAK.ADD_POSITIVE', () => {
+    const action = {
+      type: UI.CLICK_TARGET,
+      payload: { x: 5, y: 10 },
+      sourceHint: null,
+      onPeak: false,
+      onPecker: false,
+      voltammetryPeakIdx: 0,
+    } as any;
+    const iter = clickUiTarget(action);
+
+    const { value } = drainSelects(iter, [
+      LIST_UI_SWEEP_TYPE.PEAK_ADD,
+      { curveIdx: 0 },
+      { uvvis: { selectedWaveLength: null, currentSpectrum: { peaks: [] } } },
+      LIST_LAYOUT.H1, // a normal NMR layout — not LC/MS
+    ]);
+
+    expect(value).toEqual(put({
+      type: EDITPEAK.ADD_POSITIVE,
+      payload: { dataToAdd: action.payload, curveIdx: 0 },
+    }));
+  });
+
   it('PEAK_DELETE on LCMS uses REMOVE_HPLCMS_PEAK for the selected wavelength', () => {
     const action = {
       type: UI.CLICK_TARGET,

--- a/src/components/cmd_bar/r05_submit_btn.js
+++ b/src/components/cmd_bar/r05_submit_btn.js
@@ -59,19 +59,17 @@ const buildCvAxisYLabel = (yLabel, cyclicvoltaSt) => {
   return `Current in ${baseUnit}`;
 };
 
-const computeCvYScaleFactor = (feature, cyclicvoltaSt) => {
+export const computeCvYScaleFactor = (feature, cyclicvoltaSt) => {
   if (!cyclicvoltaSt?.useCurrentDensity) return 1.0;
   const rawArea = (cyclicvoltaSt.areaValue === '' ? 1.0 : cyclicvoltaSt.areaValue) || 1.0;
   const areaUnit = cyclicvoltaSt.areaUnit || 'cm²';
   const safeArea = rawArea > 0 ? rawArea : 1.0;
+  // areaInCm2 already converts mm² → cm², so factor is A/cm². Do NOT divide by 100 again.
   const areaInCm2 = areaUnit === 'mm²' ? (safeArea / 100.0) : safeArea;
   let factor = 1.0 / areaInCm2;
   const baseY = feature && feature.yUnit ? String(feature.yUnit) : 'A';
   if (/mA/i.test(baseY)) {
     factor *= 1000.0;
-  }
-  if (areaUnit === 'mm²') {
-    factor /= 100.0;
   }
   return factor;
 };

--- a/src/components/d3_line_rect/index.js
+++ b/src/components/d3_line_rect/index.js
@@ -389,15 +389,14 @@ class ViewerLineRect extends React.Component {
     if (!Array.isArray(sweepExtent)) return;
 
     const uvvisViewFeature = this.extractUvvisView();
-    if (uvvisViewFeature) {
+    if (uvvisViewFeature?.data?.[0]) {
       const hasLineSvg = !!document.querySelector(
         `${this.rootKlassLine} .${LIST_BRUSH_SVG_GRAPH.LINE}`,
       );
       if (!hasLineSvg) {
         drawMain(this.rootKlassLine, W, H, LIST_BRUSH_SVG_GRAPH.LINE);
       }
-      const { data } = uvvisViewFeature;
-      const currentData = data[0];
+      const currentData = uvvisViewFeature.data[0];
       const { x, y } = currentData;
       const uvvisSeed = toSeed(x, y);
       if (this.lineFocus) {

--- a/src/components/d3_line_rect/rect_focus.js
+++ b/src/components/d3_line_rect/rect_focus.js
@@ -140,6 +140,7 @@ class RectFocus {
     const { xt, yt } = TfRescale(this);
     this.updatePathCall(xt, yt);
 
+    if (!this.tTrEndPts.length) return;
     const yRef = this.tTrEndPts[0].y;
     const bars = this.bars.selectAll('rect')
       .data(this.data);

--- a/src/components/d3_multi/multi_focus.js
+++ b/src/components/d3_multi/multi_focus.js
@@ -183,14 +183,12 @@ class MultiFocus {
       const rawArea = (cyclicvoltaSt.areaValue === '' ? 1.0 : cyclicvoltaSt.areaValue) || 1.0;
       const areaUnit = cyclicvoltaSt.areaUnit || 'cm²';
       const safeArea = rawArea > 0 ? rawArea : 1.0;
+      // areaInCm2 already converts mm² → cm², so factor is A/cm². Do NOT divide by 100 again.
       const areaInCm2 = areaUnit === 'mm²' ? (safeArea / 100.0) : safeArea;
       factor = 1.0 / areaInCm2;
       const baseY = feature && feature.yUnit ? String(feature.yUnit) : 'A';
       if (/mA/i.test(baseY)) {
         factor *= 1000.0;
-      }
-      if (areaUnit === 'mm²') {
-        factor /= 100.0;
       }
     }
     return factor;

--- a/src/components/panel/cyclic_voltamery_data.js
+++ b/src/components/panel/cyclic_voltamery_data.js
@@ -164,13 +164,14 @@ const CyclicVoltammetryPanel = ({
     const rawArea = (cyclicVoltaState && cyclicVoltaState.areaValue === '' ? 1.0 : cyclicVoltaState?.areaValue) || 1.0;
     const areaUnit = (cyclicVoltaState && cyclicVoltaState.areaUnit) ? cyclicVoltaState.areaUnit : 'cm²';
     const safeArea = rawArea > 0 ? rawArea : 1.0;
+    const areaInCm2 = areaUnit === 'mm²' ? safeArea / 100.0 : safeArea;
 
     let val = y;
     let unit = isMilli ? 'mA' : 'A';
 
     if (useDensity) {
-      val = y / safeArea;
-      unit = `${unit}/${areaUnit}`;
+      val = y / areaInCm2;
+      unit = `${unit}/cm²`;
     }
 
     if (isMilli) {

--- a/src/helpers/chem.js
+++ b/src/helpers/chem.js
@@ -155,6 +155,13 @@ const getThreshold = (state) => (
 
 const Convert2Peak = (feature, threshold, offset, upThreshold = false, lowThreshold = false) => {
   if (feature?.operation?.layout === 'LC/MS') {
+    if (feature.peaks?.length) {
+      return feature.peaks.map((p) => ({
+        x: p.x - (offset || 0),
+        y: p.y,
+      }));
+    }
+
     const data = feature.data[0];
     if (!data) return [];
 
@@ -183,13 +190,6 @@ const Convert2Peak = (feature, threshold, offset, upThreshold = false, lowThresh
     maxY, peakUp, thresRef, minY, upperThres, lowerThres, operation,
   } = feature;
   const { layout } = operation;
-
-  if (Format.isLCMsLayout(layout) && feature.peaks) {
-    return feature.peaks.map((p) => ({
-      x: p.x - (offset || 0),
-      y: p.y,
-    }));
-  }
 
   if ((Format.isCyclicVoltaLayout(layout) || Format.isCDSLayout(layout))
   && (upperThres || lowerThres)) {

--- a/src/sagas/saga_ui.js
+++ b/src/sagas/saga_ui.js
@@ -193,19 +193,24 @@ function* clickUiTarget(action) {
   }
 
   if (uiSweepType === LIST_UI_SWEEP_TYPE.PEAK_ADD && !onPeak) {
-    const spectrumId = hplcMsState?.uvvis?.selectedWaveLength;
-    if (isLcmsLayout && spectrumId == null) return;
-    const currentPeaks = hplcMsState?.uvvis?.currentSpectrum?.peaks || [];
-
-    const updatedPeaks = [...currentPeaks, payload];
-
-    yield put({
-      type: HPLC_MS.UPDATE_HPLCMS_PEAKS,
-      payload: {
-        spectrumId,
-        peaks: updatedPeaks,
-      },
-    });
+    if (isLcmsLayout) {
+      const spectrumId = hplcMsState?.uvvis?.selectedWaveLength;
+      if (spectrumId == null) return;
+      const currentPeaks = hplcMsState?.uvvis?.currentSpectrum?.peaks || [];
+      const updatedPeaks = [...currentPeaks, payload];
+      yield put({
+        type: HPLC_MS.UPDATE_HPLCMS_PEAKS,
+        payload: {
+          spectrumId,
+          peaks: updatedPeaks,
+        },
+      });
+    } else {
+      yield put({
+        type: EDITPEAK.ADD_POSITIVE,
+        payload: { dataToAdd: payload, curveIdx },
+      });
+    }
   } else if (uiSweepType === LIST_UI_SWEEP_TYPE.PEAK_DELETE && onPeak) {
     if (isLcmsLayout && uvvis.selectedWaveLength) {
       yield* lcmsHandlePeakDelete({ uvvis, payload });


### PR DESCRIPTION
## Why

The LC/MS feature shipped to `master` via **#289**, which merged the branch at its **pre-review state**. So the regressions found while reviewing the same branch (the #232 review) are **live on `master`** — including breakage to *existing* NMR/IR/MS and CV functionality. This lands the fixes that still apply to master's current code.

> Each finding was re-verified against master's *current* code (post-#303), not blindly ported — see "Not included" below.

## Fixes

- **B1 — peak-add restored for non-LCMS layouts** (`saga_ui.js`). `PEAK_ADD` dispatched `UPDATE_HPLCMS_PEAKS` unconditionally, so clicking to add a peak on any NMR/IR/MS spectrum was a silent no-op. Restores the `EDITPEAK.ADD_POSITIVE` dispatch for non-LCMS layouts.
- **B4 — `Convert2Peak` honours stored LC/MS peaks** (`chem.js`). The LC/MS branch recomputed peaks from raw data before the stored-peaks branch, discarding user-edited `feature.peaks` and the `offset`. Stored peaks now win (with offset); the now-unreachable later branch removed.
- **B5 — CV current-density factor 100× too small for mm²**, fixed consistently across all three copies: chart (`multi_focus.computeYTransformFactor`), panel (`cyclic_voltamery_data.formatCurrent`), and submit/export (`r05_submit_btn.computeCvYScaleFactor`). The `areaInCm2` step already converts mm²→cm²; the redundant second `/100` is removed.
- **B6 — UV-Vis viewer crash** (`d3_line_rect/index.js`). `componentDidUpdate` destructured `data[0]` unguarded where `componentDidMount` guards it; selecting a wavelength whose feature lacks data threw. Mirrors the mount-side `?.data?.[0]` guard.
- **B7 — `drawBar` crash** (`rect_focus.js`). Reading `tTrEndPts[0].y` with no length check threw when the threshold was cleared while MS bars were present. Adds the empty-list guard.

## Not included — B2/B3 (deliberate)

`integration.js` `getArea`/`getAbsoluteArea` were **rewritten by #303** on master and already compute the area from the cumulative-`k` difference (`getArea`) and raw `.y` baseline (`getAbsoluteArea`). The original B2/B3 regression (double-integrating `k`) **is not present on master**, so porting the old fix would be wrong. `integration.js`/`integration.test.tsx` are untouched.

## Tests

Adds regression tests for B1, B4, B5 (chart + submit/export), B6, B7 in their per-subject suites. Full suite green in the CI Node image:

```
yarn test  →  Test Suites: 76 passed, Tests: 621 passed
```

refs #232, #289