### PR TITLE
chore: prepare release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.8.0] - 2026-06-29
+
+### Added
+- LC/MS visualization support for OpenLab and Chemstation data (#289)
+- Two-click integration: creation, split, and visual split with JCAMP persistence (#303)
+- Developer architecture documentation (#307)
+
+### Fixed
+- LC/MS review regressions B1, B4–B7 (#316):
+  - peak-add restored on non-LC/MS layouts (NMR/IR/MS)
+  - `Convert2Peak` honours stored LC/MS peaks (with offset) instead of recomputing
+  - CV current-density factor corrected for areas in mm² (chart, panel and submit/export)
+  - crash guards for the UV-Vis viewer update path and `drawBar`
+
+### CI / Build
+- GitHub Actions moved to node24 action runtimes; Node pinned to 22.23.1 (#315)
+
+### Dependencies
+- Bump http-proxy-middleware 2.0.9 → 2.0.10 (#311)
+- Bump tmp 0.2.4 → 0.2.7 (#306)
+
+[1.8.0]: https://github.com/ComPlat/react-spectra-editor/releases/tag/v1.8.0

--- a/dist/components/cmd_bar/r05_submit_btn.js
+++ b/dist/components/cmd_bar/r05_submit_btn.js
@@ -4,7 +4,7 @@ var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefau
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports.default = exports.computeCvYScaleFactor = void 0;
 var _react = _interopRequireDefault(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 var _reactRedux = require("react-redux");
@@ -59,17 +59,16 @@ const computeCvYScaleFactor = (feature, cyclicvoltaSt) => {
   const rawArea = (cyclicvoltaSt.areaValue === '' ? 1.0 : cyclicvoltaSt.areaValue) || 1.0;
   const areaUnit = cyclicvoltaSt.areaUnit || 'cm²';
   const safeArea = rawArea > 0 ? rawArea : 1.0;
+  // areaInCm2 already converts mm² → cm², so factor is A/cm². Do NOT divide by 100 again.
   const areaInCm2 = areaUnit === 'mm²' ? safeArea / 100.0 : safeArea;
   let factor = 1.0 / areaInCm2;
   const baseY = feature && feature.yUnit ? String(feature.yUnit) : 'A';
   if (/mA/i.test(baseY)) {
     factor *= 1000.0;
   }
-  if (areaUnit === 'mm²') {
-    factor /= 100.0;
-  }
   return factor;
 };
+exports.computeCvYScaleFactor = computeCvYScaleFactor;
 const defaultThreshold = {
   isEdit: true,
   value: false,

--- a/dist/components/d3_line_rect/index.js
+++ b/dist/components/d3_line_rect/index.js
@@ -396,15 +396,12 @@ class ViewerLineRect extends _react.default.Component {
     } = zoom || {};
     if (!Array.isArray(sweepExtent)) return;
     const uvvisViewFeature = this.extractUvvisView();
-    if (uvvisViewFeature) {
+    if (uvvisViewFeature?.data?.[0]) {
       const hasLineSvg = !!document.querySelector(`${this.rootKlassLine} .${_list_graph.LIST_BRUSH_SVG_GRAPH.LINE}`);
       if (!hasLineSvg) {
         (0, _draw.drawMain)(this.rootKlassLine, W, H, _list_graph.LIST_BRUSH_SVG_GRAPH.LINE);
       }
-      const {
-        data
-      } = uvvisViewFeature;
-      const currentData = data[0];
+      const currentData = uvvisViewFeature.data[0];
       const {
         x,
         y

--- a/dist/components/d3_line_rect/rect_focus.js
+++ b/dist/components/d3_line_rect/rect_focus.js
@@ -147,6 +147,7 @@ class RectFocus {
       yt
     } = (0, _compass.TfRescale)(this);
     this.updatePathCall(xt, yt);
+    if (!this.tTrEndPts.length) return;
     const yRef = this.tTrEndPts[0].y;
     const bars = this.bars.selectAll('rect').data(this.data);
     bars.exit().attr('class', 'exit').remove();

--- a/dist/components/d3_multi/multi_focus.js
+++ b/dist/components/d3_multi/multi_focus.js
@@ -189,14 +189,12 @@ class MultiFocus {
       const rawArea = (cyclicvoltaSt.areaValue === '' ? 1.0 : cyclicvoltaSt.areaValue) || 1.0;
       const areaUnit = cyclicvoltaSt.areaUnit || 'cm²';
       const safeArea = rawArea > 0 ? rawArea : 1.0;
+      // areaInCm2 already converts mm² → cm², so factor is A/cm². Do NOT divide by 100 again.
       const areaInCm2 = areaUnit === 'mm²' ? safeArea / 100.0 : safeArea;
       factor = 1.0 / areaInCm2;
       const baseY = feature && feature.yUnit ? String(feature.yUnit) : 'A';
       if (/mA/i.test(baseY)) {
         factor *= 1000.0;
-      }
-      if (areaUnit === 'mm²') {
-        factor /= 100.0;
       }
     }
     return factor;

--- a/dist/components/panel/cyclic_voltamery_data.js
+++ b/dist/components/panel/cyclic_voltamery_data.js
@@ -174,11 +174,12 @@ const CyclicVoltammetryPanel = ({
     const rawArea = (cyclicVoltaState && cyclicVoltaState.areaValue === '' ? 1.0 : cyclicVoltaState?.areaValue) || 1.0;
     const areaUnit = cyclicVoltaState && cyclicVoltaState.areaUnit ? cyclicVoltaState.areaUnit : 'cm²';
     const safeArea = rawArea > 0 ? rawArea : 1.0;
+    const areaInCm2 = areaUnit === 'mm²' ? safeArea / 100.0 : safeArea;
     let val = y;
     let unit = isMilli ? 'mA' : 'A';
     if (useDensity) {
-      val = y / safeArea;
-      unit = `${unit}/${areaUnit}`;
+      val = y / areaInCm2;
+      unit = `${unit}/cm²`;
     }
     if (isMilli) {
       val *= 1000.0;

--- a/dist/helpers/chem.js
+++ b/dist/helpers/chem.js
@@ -174,6 +174,12 @@ const ToFrequency = exports.ToFrequency = (0, _reselect.createSelector)(getLayou
 const getThreshold = state => state.threshold ? state.threshold.list[state.curve.curveIdx].value * 1.0 : false;
 const Convert2Peak = (feature, threshold, offset, upThreshold = false, lowThreshold = false) => {
   if (feature?.operation?.layout === 'LC/MS') {
+    if (feature.peaks?.length) {
+      return feature.peaks.map(p => ({
+        x: p.x - (offset || 0),
+        y: p.y
+      }));
+    }
     const data = feature.data[0];
     if (!data) return [];
     const {
@@ -209,12 +215,6 @@ const Convert2Peak = (feature, threshold, offset, upThreshold = false, lowThresh
   const {
     layout
   } = operation;
-  if (_format.default.isLCMsLayout(layout) && feature.peaks) {
-    return feature.peaks.map(p => ({
-      x: p.x - (offset || 0),
-      y: p.y
-    }));
-  }
   if ((_format.default.isCyclicVoltaLayout(layout) || _format.default.isCDSLayout(layout)) && (upperThres || lowerThres)) {
     let upperThresVal = upThreshold || upperThres;
     if (!upperThresVal) {

--- a/dist/sagas/saga_ui.js
+++ b/dist/sagas/saga_ui.js
@@ -243,17 +243,27 @@ function* clickUiTarget(action) {
     return;
   }
   if (uiSweepType === _list_ui.LIST_UI_SWEEP_TYPE.PEAK_ADD && !onPeak) {
-    const spectrumId = hplcMsState?.uvvis?.selectedWaveLength;
-    if (isLcmsLayout && spectrumId == null) return;
-    const currentPeaks = hplcMsState?.uvvis?.currentSpectrum?.peaks || [];
-    const updatedPeaks = [...currentPeaks, payload];
-    yield (0, _effects.put)({
-      type: _action_type.HPLC_MS.UPDATE_HPLCMS_PEAKS,
-      payload: {
-        spectrumId,
-        peaks: updatedPeaks
-      }
-    });
+    if (isLcmsLayout) {
+      const spectrumId = hplcMsState?.uvvis?.selectedWaveLength;
+      if (spectrumId == null) return;
+      const currentPeaks = hplcMsState?.uvvis?.currentSpectrum?.peaks || [];
+      const updatedPeaks = [...currentPeaks, payload];
+      yield (0, _effects.put)({
+        type: _action_type.HPLC_MS.UPDATE_HPLCMS_PEAKS,
+        payload: {
+          spectrumId,
+          peaks: updatedPeaks
+        }
+      });
+    } else {
+      yield (0, _effects.put)({
+        type: _action_type.EDITPEAK.ADD_POSITIVE,
+        payload: {
+          dataToAdd: payload,
+          curveIdx
+        }
+      });
+    }
   } else if (uiSweepType === _list_ui.LIST_UI_SWEEP_TYPE.PEAK_DELETE && onPeak) {
     if (isLcmsLayout && uvvis.selectedWaveLength) {
       yield* (0, _saga_lcms_ui.lcmsHandlePeakDelete)({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@complat/react-spectra-editor",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "An editor to View and Edit Chemical Spectra data (NMR, IR, MS, CV, UIVIS, XRD, GC, and DSC).",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prepares the **v1.8.0** release (current `master` is 1.7.2).

## Changes
1. **Version bump** `package.json` 1.7.2 → 1.8.0 (matches the `chore: Bump version …` convention).
2. **Clean `dist/` rebuild** — `yarn compile` in the CI Node image (`node:22.23.1`, matching `publish_package.yml`). Only **7 files changed**: exactly the source files #316 fixed, which merged to `master` without a `dist` rebuild — so the committed `dist` was stale by precisely that. The v1.8.0 tag now carries a single src-matching build. `dist/__tests__` stays gitignored; no file additions/deletions.
3. **CHANGELOG.md** (new) — starts the convention; entries derived from `git log v1.7.2..master`.

## Why keep `dist/`
`dist/` is committed intentionally: `main`/`module` → `dist/app.js`, `files: ["dist"]`, and `chemotion_ELN` consumes this repo as a **GitHub-source dependency** (no `postinstall` build). Removing it would break git-ref consumers, so this PR rebuilds rather than removes it.

## Verification
- `yarn compile` clean (234 files); `dist/*.js` syntax-check OK.
- Full suite green in `node:22.23.1`: **76 suites / 621 tests**.
- `package.json` version = 1.8.0.

## After merge (release execution — not in this PR)
1. Tag the merge commit `v1.8.0` and push.
2. Create the GitHub Release for `v1.8.0` → `publish_package.yml` builds `dist` + publishes `@complat/react-spectra-editor@1.8.0` to npm.