### PR TITLE
fix(cv): stop an incomplete feature taking the whole editor down

### DIFF
--- a/dist/components/panel/cyclic_voltamery_data.js
+++ b/dist/components/panel/cyclic_voltamery_data.js
@@ -220,10 +220,28 @@ const CyclicVoltammetryPanel = ({
     return data.max && data.min ? _format.default.strNumberFixedLength((0, _chem.GetCyclicVoltaPeakSeparate)(data.max.x, data.min.x) * 1000, 3) : 'nd';
   };
   const getRatio = (feature, data) => {
-    const featureData = feature.data[0];
-    const idx = featureData.x.indexOf(feature.maxX);
-    const y_pecker = data.pecker ? data.pecker.y : featureData.y[idx];
-    return data.max && data.min ? _format.default.strNumberFixedLength((0, _chem.GetCyclicVoltaRatio)(data.max.y, data.min.y, y_pecker), 3) : 'nd';
+    // Guard first, as getDelta above does. The ratio is only defined for a complete peak
+    // pair, and the feature is only consulted at all when this row has no pecker of its
+    // own - so nothing here should be reaching into the curve before it knows it needs to.
+    if (!data.max || !data.min) return 'nd';
+    let yPecker;
+    if (data.pecker) {
+      yPecker = data.pecker.y;
+    } else {
+      // A stored peak list can outlive the curve it was measured on: an entity may arrive
+      // with its cyclic-voltammetry data hydrated but no data block on the feature, and
+      // this panel is rendered from the peak list rather than from the curve. Dereferencing
+      // the curve unconditionally here took the whole editor down with
+      // "Cannot read properties of undefined" rather than degrading this one cell.
+      const featureData = feature?.data?.[0];
+      const xs = featureData?.x;
+      const idx = Array.isArray(xs) ? xs.indexOf(feature?.maxX) : -1;
+      yPecker = idx >= 0 ? featureData?.y?.[idx] : undefined;
+    }
+    // GetCyclicVoltaRatio would turn a missing value into NaN and render "NaN"; say
+    // "nd" instead, which is what every other cell in this table shows when unknown.
+    if (!Number.isFinite(yPecker)) return 'nd';
+    return _format.default.strNumberFixedLength((0, _chem.GetCyclicVoltaRatio)(data.max.y, data.min.y, yPecker), 3);
   };
   const rows = list.map((o, idx) => ({
     idx,

--- a/src/__tests__/units/components/panel/cyclic_voltamery_data.test.tsx
+++ b/src/__tests__/units/components/panel/cyclic_voltamery_data.test.tsx
@@ -92,3 +92,38 @@ describe('<CyclicVoltammetryPanel />', () => {
     })
   })
 });
+
+// Reported as a white screen when opening a CV analysis:
+//   TypeError: Cannot read properties of undefined (reading '0')
+//     at getRatio (cyclic_voltamery_data.js)  <- feature.data[0]
+//     at Array.map
+// getRatio dereferences feature.data[0] unconditionally, before the max/min guard that
+// decides whether the value is used at all. The surrounding component already treats the
+// feature as possibly incomplete (`feature?.data?.[0]?.x?.length` in multi_jcamps_viewer),
+// and getDelta right above it guards properly, so this one site was the outlier. A stored
+// peak list with a feature that carries no data block is enough to take the whole editor
+// down.
+describe('<CyclicVoltammetryPanel /> with an incomplete feature', () => {
+  const renderWith = (feature: any): RenderResult => render(
+    <Provider store={store}>
+      <CyclicVoltammetryPanel
+        expand={false}
+        onExapnd={() => {}}
+        molSvg=""
+        feature={feature}
+      />
+    </Provider>,
+  );
+
+  it('renders when the feature carries no data block', () => {
+    expect(() => renderWith({ xUnit: 'V', yUnit: 'A', maxX: 1.0 })).not.toThrow();
+  });
+
+  it('renders when the feature has an empty data array', () => {
+    expect(() => renderWith({ xUnit: 'V', yUnit: 'A', maxX: 1.0, data: [] })).not.toThrow();
+  });
+
+  it('renders when the data block has no x/y arrays', () => {
+    expect(() => renderWith({ xUnit: 'V', yUnit: 'A', maxX: 1.0, data: [{}] })).not.toThrow();
+  });
+});

--- a/src/components/panel/cyclic_voltamery_data.js
+++ b/src/components/panel/cyclic_voltamery_data.js
@@ -208,10 +208,32 @@ const CyclicVoltammetryPanel = ({
   };
 
   const getRatio = (feature, data) => {
-    const featureData = feature.data[0];
-    const idx = featureData.x.indexOf(feature.maxX);
-    const y_pecker = data.pecker ? data.pecker.y : featureData.y[idx];
-    return (data.max && data.min) ? Format.strNumberFixedLength(GetCyclicVoltaRatio(data.max.y, data.min.y, y_pecker), 3) : 'nd';
+    // Guard first, as getDelta above does. The ratio is only defined for a complete peak
+    // pair, and the feature is only consulted at all when this row has no pecker of its
+    // own - so nothing here should be reaching into the curve before it knows it needs to.
+    if (!data.max || !data.min) return 'nd';
+
+    let yPecker;
+    if (data.pecker) {
+      yPecker = data.pecker.y;
+    } else {
+      // A stored peak list can outlive the curve it was measured on: an entity may arrive
+      // with its cyclic-voltammetry data hydrated but no data block on the feature, and
+      // this panel is rendered from the peak list rather than from the curve. Dereferencing
+      // the curve unconditionally here took the whole editor down with
+      // "Cannot read properties of undefined" rather than degrading this one cell.
+      const featureData = feature?.data?.[0];
+      const xs = featureData?.x;
+      const idx = Array.isArray(xs) ? xs.indexOf(feature?.maxX) : -1;
+      yPecker = idx >= 0 ? featureData?.y?.[idx] : undefined;
+    }
+    // GetCyclicVoltaRatio would turn a missing value into NaN and render "NaN"; say
+    // "nd" instead, which is what every other cell in this table shows when unknown.
+    if (!Number.isFinite(yPecker)) return 'nd';
+
+    return Format.strNumberFixedLength(
+      GetCyclicVoltaRatio(data.max.y, data.min.y, yPecker), 3,
+    );
   };
 
   const rows = list.map((o, idx) => (


### PR DESCRIPTION
## Problem

Opening a cyclic voltammetry analysis white-screens the editor:

```
TypeError: Cannot read properties of undefined (reading '0')
    at getRatio    <- feature.data[0]
    at Array.map
```

## Cause

`getRatio` dereferences `feature.data[0]` **unconditionally**, before the `max && min` guard that decides whether a ratio is defined at all — so a stored peak list is enough to reach into the curve even for a row that was only ever going to render `nd`:

```js
const featureData = feature.data[0];                 // ← crash
const idx = featureData.x.indexOf(feature.maxX);
const y_pecker = data.pecker ? data.pecker.y : featureData.y[idx];
return (data.max && data.min) ? … : 'nd';            // ← guard, too late
```

`getDelta` immediately above it guards properly, and the caller already treats the feature as possibly incomplete (`feature?.data?.[0]?.x?.length` in `multi_jcamps_viewer`), so this one site was the outlier.

A peak list can outlive the curve it was measured on — an entity can arrive with its cyclic-voltammetry data hydrated but no data block on the feature, and this panel renders from the peak list, not from the curve.

There are three ways in, each crashing differently, all reproduced as tests:

| feature | error |
|---|---|
| no `data` | `Cannot read properties of undefined (reading '0')` |
| `data: []` | `… (reading 'x')` |
| `data: [{}]` | `… (reading 'indexOf')` |

## Fix

Guard first, consult the curve only in the branch that actually needs it (a row with no pecker of its own), and fall back to `nd` when the value can't be determined — which is what every other cell in the table already shows when unknown.

That also replaces a rendered `NaN` in the case where the x lookup missed: `GetCyclicVoltaRatio` propagates a missing value rather than rejecting it.

**Behaviour for a healthy curve is unchanged** — the existing `render table cells` test pins the rendered ratios (`0.97`, `0.97`, `nd`) and still passes.

## Test plan

- [x] Three regression tests reproducing each crash mode, failing before the fix with the exact reported error and passing after.
- [x] 78 suites / 728 unit tests pass.
- [x] Production build compiles clean through its lint gate.
- [x] Full e2e **81/81**, `cv_spec` 6/6.
- [ ] Confirm against the affected dataset in the ELN.

## Context

This is the proximate cause of the white screen. What leaves the feature without a data block in the first place is likely upstream — ComPlat/chemotion_ELN#3531 restores peak generation for derived jcamps, which is what produced the half-generated CV datasets this was seen on. This fix stands on its own regardless: one incomplete curve should degrade one table cell, not take down the editor.