### PR TITLE
chore: prepare release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.8.2] - 2026-08-27
+
+### Fixed
+- LC/MS retention time is normalized to minutes and the UV and TIC panes share an aligned domain (#323)
+- LC/MS: a UV/VIS axis delivered in seconds behind a MINUTES label is corrected (#326)
+- LC/MS: the three-graph stack, the toolbar and the panel now fit their container (#325)
+- CV: an incomplete feature no longer takes the whole editor down (#327)
+
+[1.8.2]: https://github.com/ComPlat/react-spectra-editor/releases/tag/v1.8.2
+
 ## [1.8.1] - 2026-08-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@complat/react-spectra-editor",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "An editor to View and Edit Chemical Spectra data (NMR, IR, MS, CV, UIVIS, XRD, GC, and DSC).",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Patch release covering the four commits on `master` since v1.8.1.

## Contents

- `fix(lcms)`: retention time normalized to minutes, UV/TIC pane domains aligned (#323)
- `fix(lcms)`: a UV/VIS axis arriving in seconds behind a MINUTES label is corrected (#326)
- `fix(lcms)`: the three-graph stack, toolbar and panel fit their container (#325)
- `fix(cv)`: an incomplete feature no longer takes the whole editor down (#327)

## Commits

1. `chore: Bump version from 1.8.1 to 1.8.2` — `package.json` only
2. `docs: add CHANGELOG for 1.8.2` — newest entry on top

No `build: recompile dist` commit this time: a clean rebuild in `node:22.23.1`
(`yarn install --frozen-lockfile && yarn compile`) reproduced the committed `dist/`
byte-for-byte, since #323/#325/#326/#327 each merged with their `dist/` output.
Verified the `dist/` files that chemotion_ELN's `package_postinstall.sh` patches by
path still carry exactly one `const d3 = require('d3');` each, so ELN's install is
unaffected.

## After merge (release execution — not in this PR)
1. Tag the merge commit `v1.8.2` and push.
2. Create the GitHub Release for `v1.8.2` → `publish_package.yml` builds `dist` + publishes `@complat/react-spectra-editor@1.8.2` to npm.