### PR TITLE
fix(multi-curve): stop infinite update loop and make Clear All Peaks persist

### DIFF
--- a/dist/components/cmd_bar/03_peak.js
+++ b/dist/components/cmd_bar/03_peak.js
@@ -58,7 +58,7 @@ const Peak = ({
     if (layoutSt === _list_layout.LIST_LAYOUT.LC_MS) {
       clearAllPeaksHplcMsAct();
     } else {
-      const dataPeaks = (0, _extractPeaksEdit.extractAutoPeaks)(feature, thresSt, shiftSt, layoutSt);
+      const dataPeaks = (0, _extractPeaksEdit.extractAutoPeaks)(feature, thresSt, shiftSt, layoutSt, curveIdx);
       clearAllPeaksAct({
         curveIdx,
         dataPeaks

--- a/dist/components/forecast_viewer.js
+++ b/dist/components/forecast_viewer.js
@@ -19,6 +19,29 @@ var _list_ui = require("../constants/list_ui");
 var _jsxRuntime = require("react/jsx-runtime");
 /* eslint-disable react/no-unused-prop-types */
 
+// A host that rebuilds `forecast` as a fresh object literal on every render
+// (no memoization on its side) must not make ForecastViewer re-dispatch
+// FORECAST.INIT_STATUS on every single re-render regardless of whether the
+// prediction data actually changed - only `predictions`/`molecule` drive
+// initForecastReducer's effect, so compare those by content instead of the
+// whole `forecast` object by reference.
+const forecastSignature = forecast => {
+  if (!forecast || typeof forecast !== 'object') return 'none';
+  const {
+    predictions,
+    molecule
+  } = forecast;
+  try {
+    return JSON.stringify({
+      predictions,
+      molecule
+    });
+  } catch (e) {
+    // Unstringifiable content (e.g. a circular structure): never treat as
+    // equal, so we fall back to the old always-refresh behavior.
+    return null;
+  }
+};
 const styles = () => ({
   root: {
     flexGrow: 1
@@ -43,9 +66,9 @@ class ForecastViewer extends _react.default.Component {
     const {
       forecast
     } = this.props;
-    const prevForecast = forecast;
-    const nextForecast = prevProps.forecast;
-    if (prevForecast !== nextForecast) {
+    const prevSig = forecastSignature(prevProps.forecast);
+    const nextSig = forecastSignature(forecast);
+    if (prevSig === null || nextSig === null || prevSig !== nextSig) {
       this.initForecastReducer();
     }
   }

--- a/dist/helpers/entity_signature.js
+++ b/dist/helpers/entity_signature.js
@@ -1,0 +1,64 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.multiEntitiesSignature = exports.entitySignature = exports.dataBlockDigest = void 0;
+// Content fingerprints for host-supplied entities.
+//
+// Hosts routinely rebuild `entity` / `multiEntities` as fresh object literals on
+// every render, so reference equality cannot answer "did the data actually
+// change?". Answering it with `!==` is what cascaded into React's "Maximum
+// update depth exceeded" in issue #329. These helpers answer it by content
+// instead.
+//
+// Entities carry large spectral arrays, so nothing here stringifies one
+// wholesale; each data block is reduced to length/first/last per axis.
+
+// Digest of a single `{ x, y }` data block, on BOTH axes.
+const dataBlockDigest = data0 => {
+  if (!data0) return 'none';
+  const xs = Array.isArray(data0.x) ? data0.x : [];
+  const ys = Array.isArray(data0.y) ? data0.y : [];
+  return `${xs.length}:${xs[0]}:${xs[xs.length - 1]}:${ys.length}:${ys[0]}:${ys[ys.length - 1]}`;
+};
+
+// A stable content signature for one entity.
+//
+// Three properties this digest must have, each learned from a way an easier
+// signature collides between two genuinely different entities:
+//
+//  - It must not key on the id alone. `idDt` is a DATASET-scope key shared by
+//    every curve of an LC/MS group (see reducer_hplc_ms/hydrate.js's
+//    `lcmsDatasetKey`), so an id-only signature stays constant for a whole
+//    session - a host answering `onLcmsPageRequest` with a new retention time
+//    would look unchanged. The id is folded in as one component, never as a
+//    short-circuit.
+//  - It must digest every `spectra` block, not just the first: an MS-layout
+//    entity's displayed topic comes from `spectra[scanIdx]` (chosen by
+//    getScanIdx), not `spectra[0]`.
+//  - It must digest both axes. Many instrument types - IR in particular -
+//    resample every measurement onto the same standardized wavenumber grid, so
+//    two completely different samples share an identical x length/head/tail
+//    while only their measured y values differ.
+//
+// The feature blocks extractParams itself reads (autoPeak/editPeak) are folded
+// in too, so a mismatch anywhere in what extractParams consumes shows up here.
+exports.dataBlockDigest = dataBlockDigest;
+const entitySignature = e => {
+  if (!e) return 'none';
+  const id = e.idDt ?? e.id ?? e.datasetId;
+  const spectraDigest = Array.isArray(e.spectra) ? e.spectra.map(s => dataBlockDigest(s?.data?.[0])).join(';') : 'none';
+  const features = e.features && typeof e.features === 'object' && !Array.isArray(e.features) ? e.features : {};
+  const autoDigest = dataBlockDigest(features.autoPeak?.data?.[0]);
+  const editDigest = dataBlockDigest(features.editPeak?.data?.[0]);
+  return `${e.layout || ''}|${e.title || ''}|id:${id ?? ''}|sp:${spectraDigest}|auto:${autoDigest}|edit:${editDigest}`;
+};
+
+// Signature for a list of entities (`multiEntities`).
+exports.entitySignature = entitySignature;
+const multiEntitiesSignature = entities => {
+  if (!Array.isArray(entities)) return 'none';
+  return `len:${entities.length}|${entities.map(e => entitySignature(e)).join('||')}`;
+};
+exports.multiEntitiesSignature = multiEntitiesSignature;

--- a/dist/layer_init.js
+++ b/dist/layer_init.js
@@ -40,6 +40,10 @@ class LayerInit extends _react.default.Component {
     const xTail = Array.isArray(xs) && xs.length > 0 ? xs[xs.length - 1] : '';
     return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
   }
+  static multiEntitiesSignature(entities) {
+    if (!Array.isArray(entities)) return 'none';
+    return `len:${entities.length}|${entities.map(e => LayerInit.entitySignature(e)).join('||')}`;
+  }
   constructor(props) {
     super(props);
     this.normChange = this.normChange.bind(this);
@@ -61,24 +65,25 @@ class LayerInit extends _react.default.Component {
       entity,
       operations
     } = this.props;
-    this.normChange(prevProps);
-    if (prevProps.operations !== operations || prevProps.entity !== entity) {
+    const entityChanged = LayerInit.entitySignature(prevProps.entity) !== LayerInit.entitySignature(entity);
+    this.normChange(prevProps, entityChanged);
+    if (prevProps.operations !== operations || entityChanged) {
       this.initReducer();
     }
     if (prevProps.others !== others) {
       this.updateOthers();
     }
-    if (prevProps.multiEntities !== multiEntities || prevProps.entity !== entity) {
+    if (LayerInit.multiEntitiesSignature(prevProps.multiEntities) !== LayerInit.multiEntitiesSignature(multiEntities) || entityChanged) {
       this.updateMultiEntities();
     }
   }
-  normChange(prevProps) {
+  normChange(prevProps, entityChanged) {
     const {
       entity,
       multiEntities,
       clearHplcMsStateAct
     } = this.props;
-    if (prevProps.entity !== entity) {
+    if (entityChanged) {
       const prevIsLcms = _format.default.isLCMsLayout(prevProps.entity?.layout);
       const nextIsLcms = _format.default.isLCMsLayout(entity?.layout);
       const lcmsSessionActive = prevIsLcms && nextIsLcms && Array.isArray(multiEntities) && (0, _extractEntityLCMS.isLcMsGroup)(multiEntities);

--- a/dist/layer_init.js
+++ b/dist/layer_init.js
@@ -17,6 +17,7 @@ var _meta = require("./actions/meta");
 var _jcamp = require("./actions/jcamp");
 var _layer_prism = _interopRequireDefault(require("./layer_prism"));
 var _format = _interopRequireDefault(require("./helpers/format"));
+var _entity_signature = require("./helpers/entity_signature");
 var _extractEntityLCMS = require("./helpers/extractEntityLCMS");
 var _timeAxis = require("./features/lc-ms/entities/timeAxis");
 var _multi_jcamps_viewer = _interopRequireDefault(require("./components/multi_jcamps_viewer"));
@@ -28,22 +29,6 @@ var _jsxRuntime = require("react/jsx-runtime");
 
 const styles = () => ({});
 class LayerInit extends _react.default.Component {
-  static entitySignature(e) {
-    if (!e) return 'none';
-    const id = e.idDt ?? e.id ?? e.datasetId;
-    if (id != null && id !== '') return `id:${id}`;
-    const firstFeature = (Array.isArray(e.features) ? e.features[0] : null) || (Array.isArray(e.spectra) ? e.spectra[0] : null) || null;
-    const data0 = firstFeature?.data?.[0];
-    const xs = data0?.x;
-    const xLen = Array.isArray(xs) ? xs.length : 0;
-    const xHead = Array.isArray(xs) && xs.length > 0 ? xs[0] : '';
-    const xTail = Array.isArray(xs) && xs.length > 0 ? xs[xs.length - 1] : '';
-    return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
-  }
-  static multiEntitiesSignature(entities) {
-    if (!Array.isArray(entities)) return 'none';
-    return `len:${entities.length}|${entities.map(e => LayerInit.entitySignature(e)).join('||')}`;
-  }
   constructor(props) {
     super(props);
     this.normChange = this.normChange.bind(this);
@@ -65,7 +50,7 @@ class LayerInit extends _react.default.Component {
       entity,
       operations
     } = this.props;
-    const entityChanged = LayerInit.entitySignature(prevProps.entity) !== LayerInit.entitySignature(entity);
+    const entityChanged = (0, _entity_signature.entitySignature)(prevProps.entity) !== (0, _entity_signature.entitySignature)(entity);
     this.normChange(prevProps, entityChanged);
     if (prevProps.operations !== operations || entityChanged) {
       this.initReducer();
@@ -73,7 +58,7 @@ class LayerInit extends _react.default.Component {
     if (prevProps.others !== others) {
       this.updateOthers();
     }
-    if (LayerInit.multiEntitiesSignature(prevProps.multiEntities) !== LayerInit.multiEntitiesSignature(multiEntities) || entityChanged) {
+    if ((0, _entity_signature.multiEntitiesSignature)(prevProps.multiEntities) !== (0, _entity_signature.multiEntitiesSignature)(multiEntities) || entityChanged) {
       this.updateMultiEntities();
     }
   }
@@ -88,8 +73,8 @@ class LayerInit extends _react.default.Component {
       const nextIsLcms = _format.default.isLCMsLayout(entity?.layout);
       const lcmsSessionActive = prevIsLcms && nextIsLcms && Array.isArray(multiEntities) && (0, _extractEntityLCMS.isLcMsGroup)(multiEntities);
       if ((prevIsLcms || nextIsLcms) && !lcmsSessionActive) {
-        const prevSig = LayerInit.entitySignature(prevProps.entity);
-        const nextSig = LayerInit.entitySignature(entity);
+        const prevSig = (0, _entity_signature.entitySignature)(prevProps.entity);
+        const nextSig = (0, _entity_signature.entitySignature)(entity);
         if (prevSig !== nextSig) {
           clearHplcMsStateAct();
         }

--- a/dist/layer_prism.js
+++ b/dist/layer_prism.js
@@ -39,20 +39,37 @@ const getThresholdState = state => {
 // whenever `feature`'s reference changes, and that cascades into a fresh
 // state.threshold reference, causing LayerPrism to re-render and rebuild
 // `feature` again, and so on, once per host render. Since `entity` can carry
-// large spectral data arrays, avoid stringifying it wholesale; use the same
-// lightweight id/shape signature LayerInit already uses to detect "same
-// dataset, new reference".
+// large spectral data arrays, avoid stringifying it wholesale; digest only
+// each data block's length/first/last on BOTH axes.
+//
+// Unlike LayerInit's own (lower-stakes) entitySignature helper - which only
+// gates whether to re-dispatch a redux init action, so a false "unchanged"
+// merely skips a re-init - this signature directly gates what actually gets
+// RENDERED, so it must not collide between two genuinely different entities.
+// An X-only, first-spectrum-only digest is not safe enough for that: many
+// instrument types (IR in particular) resample every measurement onto the
+// same standardized wavenumber grid, so two completely different samples
+// can share identical x length/head/tail while their y (measured) values
+// differ - and an entity's actually-displayed data is not always its first
+// spectra entry (an MS-layout entity's topic comes from spectra[scanIdx],
+// selected by getScanIdx, not spectra[0]). Digest every spectrum block (not
+// just the first) and both axes, plus the feature blocks extractParams
+// itself reads (autoPeak/editPeak), so a mismatch anywhere in what
+// extractParams actually consumes invalidates the cache.
+const dataBlockDigest = data0 => {
+  if (!data0) return 'none';
+  const xs = Array.isArray(data0.x) ? data0.x : [];
+  const ys = Array.isArray(data0.y) ? data0.y : [];
+  return `${xs.length}:${xs[0]}:${xs[xs.length - 1]}:${ys.length}:${ys[0]}:${ys[ys.length - 1]}`;
+};
 const entitySignature = e => {
   if (!e) return 'none';
   const id = e.idDt ?? e.id ?? e.datasetId;
-  if (id != null && id !== '') return `id:${id}`;
-  const firstFeature = (Array.isArray(e.features) ? e.features[0] : null) || (Array.isArray(e.spectra) ? e.spectra[0] : null) || null;
-  const data0 = firstFeature?.data?.[0];
-  const xs = data0?.x;
-  const xLen = Array.isArray(xs) ? xs.length : 0;
-  const xHead = Array.isArray(xs) && xs.length > 0 ? xs[0] : '';
-  const xTail = Array.isArray(xs) && xs.length > 0 ? xs[xs.length - 1] : '';
-  return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
+  const spectraDigest = Array.isArray(e.spectra) ? e.spectra.map(s => dataBlockDigest(s?.data?.[0])).join(';') : 'none';
+  const features = e.features && typeof e.features === 'object' && !Array.isArray(e.features) ? e.features : {};
+  const autoDigest = dataBlockDigest(features.autoPeak?.data?.[0]);
+  const editDigest = dataBlockDigest(features.editPeak?.data?.[0]);
+  return `${e.layout || ''}|${e.title || ''}|id:${id ?? ''}|sp:${spectraDigest}|auto:${autoDigest}|edit:${editDigest}`;
 };
 const useExtractedParams = (entity, thresSt, scanSt) => {
   const signature = `${entitySignature(entity)}|${JSON.stringify(thresSt)}|${JSON.stringify(scanSt)}`;

--- a/dist/layer_prism.js
+++ b/dist/layer_prism.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-var _react = _interopRequireDefault(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 var _propTypes = _interopRequireDefault(require("prop-types"));
 var _reactRedux = require("react-redux");
 var _redux = require("redux");
@@ -18,6 +18,7 @@ var _list_ui = require("./constants/list_ui");
 var _extractParams = require("./helpers/extractParams");
 var _list_graph = require("./constants/list_graph");
 var _jsxRuntime = require("react/jsx-runtime");
+function _interopRequireWildcard(e, t) { if ("function" == typeof WeakMap) var r = new WeakMap(), n = new WeakMap(); return (_interopRequireWildcard = function _interopRequireWildcard(e, t) { if (!t && e && e.__esModule) return e; var o, i, f = { __proto__: null, default: e }; if (null === e || "object" != typeof e && "function" != typeof e) return f; if (o = t ? n : r) { if (o.has(e)) return o.get(e); o.set(e, f); } for (const t in e) "default" !== t && {}.hasOwnProperty.call(e, t) && ((i = (o = Object.defineProperty) && Object.getOwnPropertyDescriptor(e, t)) && (i.get || i.set) ? o(f, t, i) : f[t] = e[t]); return f; })(e, t); }
 /* eslint-disable prefer-object-spread, default-param-last,
 react/function-component-definition, react/require-default-props
 */
@@ -29,6 +30,40 @@ const getThresholdState = state => {
   if (!Array.isArray(thresholdList)) return {};
   if (!Number.isInteger(curveIdx)) return thresholdList[0] || {};
   return thresholdList[curveIdx] || thresholdList[0] || {};
+};
+
+// A host that rebuilds `entity` as a fresh object literal on every render
+// (no memoization on its side) must not hand ViewerLine (via extractParams'
+// `feature`) a brand-new object every single time regardless of whether the
+// underlying data changed - ViewerLine.normChange dispatches MANAGER.RESETALL
+// whenever `feature`'s reference changes, and that cascades into a fresh
+// state.threshold reference, causing LayerPrism to re-render and rebuild
+// `feature` again, and so on, once per host render. Since `entity` can carry
+// large spectral data arrays, avoid stringifying it wholesale; use the same
+// lightweight id/shape signature LayerInit already uses to detect "same
+// dataset, new reference".
+const entitySignature = e => {
+  if (!e) return 'none';
+  const id = e.idDt ?? e.id ?? e.datasetId;
+  if (id != null && id !== '') return `id:${id}`;
+  const firstFeature = (Array.isArray(e.features) ? e.features[0] : null) || (Array.isArray(e.spectra) ? e.spectra[0] : null) || null;
+  const data0 = firstFeature?.data?.[0];
+  const xs = data0?.x;
+  const xLen = Array.isArray(xs) ? xs.length : 0;
+  const xHead = Array.isArray(xs) && xs.length > 0 ? xs[0] : '';
+  const xTail = Array.isArray(xs) && xs.length > 0 ? xs[xs.length - 1] : '';
+  return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
+};
+const useExtractedParams = (entity, thresSt, scanSt) => {
+  const signature = `${entitySignature(entity)}|${JSON.stringify(thresSt)}|${JSON.stringify(scanSt)}`;
+  const cacheRef = (0, _react.useRef)(null);
+  if (!cacheRef.current || cacheRef.current.signature !== signature) {
+    cacheRef.current = {
+      signature,
+      result: (0, _extractParams.extractParams)(entity, thresSt, scanSt)
+    };
+  }
+  return cacheRef.current.result;
 };
 const LayerPrism = ({
   entity,
@@ -57,7 +92,7 @@ const LayerPrism = ({
     hasEdit,
     integration: initialIntegration,
     features
-  } = (0, _extractParams.extractParams)(entity, thresSt, scanSt);
+  } = useExtractedParams(entity, thresSt, scanSt);
   if (!topic) return null;
   const curveIdx = curveSt && Number.isFinite(curveSt.curveIdx) ? curveSt.curveIdx : 0;
   const liveIntegrations = integrationSt && Array.isArray(integrationSt.integrations) ? integrationSt.integrations : null;

--- a/dist/layer_prism.js
+++ b/dist/layer_prism.js
@@ -16,6 +16,7 @@ var _index2 = _interopRequireDefault(require("./components/cmd_bar/index"));
 var _layer_content = _interopRequireDefault(require("./layer_content"));
 var _list_ui = require("./constants/list_ui");
 var _extractParams = require("./helpers/extractParams");
+var _entity_signature = require("./helpers/entity_signature");
 var _list_graph = require("./constants/list_graph");
 var _jsxRuntime = require("react/jsx-runtime");
 function _interopRequireWildcard(e, t) { if ("function" == typeof WeakMap) var r = new WeakMap(), n = new WeakMap(); return (_interopRequireWildcard = function _interopRequireWildcard(e, t) { if (!t && e && e.__esModule) return e; var o, i, f = { __proto__: null, default: e }; if (null === e || "object" != typeof e && "function" != typeof e) return f; if (o = t ? n : r) { if (o.has(e)) return o.get(e); o.set(e, f); } for (const t in e) "default" !== t && {}.hasOwnProperty.call(e, t) && ((i = (o = Object.defineProperty) && Object.getOwnPropertyDescriptor(e, t)) && (i.get || i.set) ? o(f, t, i) : f[t] = e[t]); return f; })(e, t); }
@@ -32,47 +33,20 @@ const getThresholdState = state => {
   return thresholdList[curveIdx] || thresholdList[0] || {};
 };
 
-// A host that rebuilds `entity` as a fresh object literal on every render
-// (no memoization on its side) must not hand ViewerLine (via extractParams'
+// A host that rebuilds `entity` as a fresh object literal on every render (no
+// memoization on its side) must not hand ViewerLine (via extractParams'
 // `feature`) a brand-new object every single time regardless of whether the
 // underlying data changed - ViewerLine.normChange dispatches MANAGER.RESETALL
 // whenever `feature`'s reference changes, and that cascades into a fresh
 // state.threshold reference, causing LayerPrism to re-render and rebuild
-// `feature` again, and so on, once per host render. Since `entity` can carry
-// large spectral data arrays, avoid stringifying it wholesale; digest only
-// each data block's length/first/last on BOTH axes.
+// `feature` again, and so on, once per host render.
 //
-// Unlike LayerInit's own (lower-stakes) entitySignature helper - which only
-// gates whether to re-dispatch a redux init action, so a false "unchanged"
-// merely skips a re-init - this signature directly gates what actually gets
-// RENDERED, so it must not collide between two genuinely different entities.
-// An X-only, first-spectrum-only digest is not safe enough for that: many
-// instrument types (IR in particular) resample every measurement onto the
-// same standardized wavenumber grid, so two completely different samples
-// can share identical x length/head/tail while their y (measured) values
-// differ - and an entity's actually-displayed data is not always its first
-// spectra entry (an MS-layout entity's topic comes from spectra[scanIdx],
-// selected by getScanIdx, not spectra[0]). Digest every spectrum block (not
-// just the first) and both axes, plus the feature blocks extractParams
-// itself reads (autoPeak/editPeak), so a mismatch anywhere in what
-// extractParams actually consumes invalidates the cache.
-const dataBlockDigest = data0 => {
-  if (!data0) return 'none';
-  const xs = Array.isArray(data0.x) ? data0.x : [];
-  const ys = Array.isArray(data0.y) ? data0.y : [];
-  return `${xs.length}:${xs[0]}:${xs[xs.length - 1]}:${ys.length}:${ys[0]}:${ys[ys.length - 1]}`;
-};
-const entitySignature = e => {
-  if (!e) return 'none';
-  const id = e.idDt ?? e.id ?? e.datasetId;
-  const spectraDigest = Array.isArray(e.spectra) ? e.spectra.map(s => dataBlockDigest(s?.data?.[0])).join(';') : 'none';
-  const features = e.features && typeof e.features === 'object' && !Array.isArray(e.features) ? e.features : {};
-  const autoDigest = dataBlockDigest(features.autoPeak?.data?.[0]);
-  const editDigest = dataBlockDigest(features.editPeak?.data?.[0]);
-  return `${e.layout || ''}|${e.title || ''}|id:${id ?? ''}|sp:${spectraDigest}|auto:${autoDigest}|edit:${editDigest}`;
-};
+// This signature gates what actually gets RENDERED, so it must not collide
+// between two genuinely different entities; see helpers/entity_signature for
+// why it digests every spectra block on both axes rather than just the first
+// block's x values.
 const useExtractedParams = (entity, thresSt, scanSt) => {
-  const signature = `${entitySignature(entity)}|${JSON.stringify(thresSt)}|${JSON.stringify(scanSt)}`;
+  const signature = `${(0, _entity_signature.entitySignature)(entity)}|${JSON.stringify(thresSt)}|${JSON.stringify(scanSt)}`;
   const cacheRef = (0, _react.useRef)(null);
   if (!cacheRef.current || cacheRef.current.signature !== signature) {
     cacheRef.current = {

--- a/dist/reducers/reducer_edit_peak.js
+++ b/dist/reducers/reducer_edit_peak.js
@@ -188,7 +188,10 @@ const clearAllPeaks = (state, action) => {
   const {
     peaks
   } = state;
-  const selectedEditPeaks = peaks[curveIdx];
+  let selectedEditPeaks = peaks[curveIdx];
+  if (!selectedEditPeaks) {
+    selectedEditPeaks = defaultEmptyPeaks;
+  }
   const {
     pos
   } = selectedEditPeaks;

--- a/dist/reducers/reducer_edit_peak.js
+++ b/dist/reducers/reducer_edit_peak.js
@@ -199,7 +199,8 @@ const clearAllPeaks = (state, action) => {
   const newPeaks = [...peaks];
   newPeaks[curveIdx] = newSelectedEditPeaks;
   return Object.assign({}, state, {
-    peaks: newPeaks
+    peaks: newPeaks,
+    selectedIdx: curveIdx
   });
 };
 const editPeakReducer = (state = initialState, action) => {

--- a/src/__tests__/units/components/cmd_bar/03_peak.test.js
+++ b/src/__tests__/units/components/cmd_bar/03_peak.test.js
@@ -1,10 +1,15 @@
 import configureStore from 'redux-mock-store'
 import { Provider } from 'react-redux'
-import { render } from '@testing-library/react'; 
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Peak from '../../../../components/cmd_bar/03_peak';
 import { LIST_UI_SWEEP_TYPE } from '../../../../constants/list_ui';
 import { LIST_LAYOUT } from '../../../../constants/list_layout';
+import { extractAutoPeaks } from '../../../../helpers/extractPeaksEdit';
+
+jest.mock('../../../../helpers/extractPeaksEdit', () => ({
+  extractAutoPeaks: jest.fn(() => []),
+}));
 
 const mockStore = configureStore([]);
 const store = mockStore({
@@ -102,5 +107,44 @@ describe('<Peak />', () => {
     const renderResult = queryByTestId('Peak');
     expect(renderResult).toBeInTheDocument();
     expect(renderResult.childElementCount).toEqual(3);
+  });
+
+  it('Clear All Peaks uses the selected curve\'s shift offset, not curve 0\'s', () => {
+    extractAutoPeaks.mockClear();
+    const curveIdx = 2;
+    const nonZeroCurveStore = mockStore({
+      ui: { sweepType: LIST_UI_SWEEP_TYPE.ZOOMIN },
+      layout: LIST_LAYOUT.H1,
+      curve: { curveIdx },
+      editPeak: {
+        present: {
+          selectedIdx: 0,
+          peaks: [{ prevOffset: 0, pos: [], neg: [] }],
+        },
+      },
+      threshold: {
+        selectedIdx: 0,
+        list: [
+          { isEdit: true, value: false, upper: false, lower: false },
+          { isEdit: true, value: false, upper: false, lower: false },
+          { isEdit: true, value: false, upper: false, lower: false },
+        ],
+      },
+      shift: { shifts: [] },
+      cyclicvolta: {},
+    });
+    nonZeroCurveStore.dispatch = jest.fn(dispatchMock);
+
+    const { container } = render(
+      <AppWrapper store={nonZeroCurveStore}>
+        <Peak feature={{}} />
+      </AppWrapper>,
+    );
+
+    fireEvent.click(container.querySelector('.btn-sv-bar-one'));
+    fireEvent.click(container.querySelector('.btn-sv-bar-yes'));
+
+    expect(extractAutoPeaks).toHaveBeenCalledTimes(1);
+    expect(extractAutoPeaks.mock.calls[0][4]).toEqual(curveIdx);
   });
 })

--- a/src/__tests__/units/components/forecast_viewer.test.tsx
+++ b/src/__tests__/units/components/forecast_viewer.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import ForecastViewer from '../../../components/forecast_viewer';
+
+jest.mock('../../../components/d3_line/index', () => () => <div data-testid="viewer-line" />);
+jest.mock('../../../components/forecast/nmr_viewer', () => () => <div />);
+jest.mock('../../../components/forecast/ir_viewer', () => () => <div />);
+
+const mockStore = configureStore([]);
+
+const storeState = {
+  ui: { viewer: 'SPECTRUM' },
+  jcamp: { jcamps: [{ others: [] }] },
+  wavelength: {},
+  curve: { curveIdx: 0 },
+};
+
+const baseProps = {
+  topic: {},
+  feature: {},
+  cLabel: '',
+  xLabel: '',
+  yLabel: '',
+  isNmr: false,
+  isIr: false,
+  isUvvis: false,
+  isXRD: false,
+};
+
+describe('ForecastViewer — does not re-dispatch FORECAST.INIT_STATUS on host-churned-but-equivalent forecast', () => {
+  it('dispatches once on mount, not again for a fresh-but-content-equal forecast object', () => {
+    const store = mockStore(storeState);
+    store.dispatch = jest.fn(() => Promise.resolve({}));
+
+    const forecastA = { molecule: { id: 1 }, predictions: { running: false } };
+    const { rerender } = render(
+      <Provider store={store}>
+        <ForecastViewer {...baseProps} forecast={forecastA} />
+      </Provider>,
+    );
+    const dispatchCountAfterMount = (store.dispatch as jest.Mock).mock.calls.length;
+    expect(dispatchCountAfterMount).toBeGreaterThan(0);
+
+    for (let i = 0; i < 5; i += 1) {
+      const forecastEquivalent = { molecule: { id: 1 }, predictions: { running: false } };
+      rerender(
+        <Provider store={store}>
+          <ForecastViewer {...baseProps} forecast={forecastEquivalent} />
+        </Provider>,
+      );
+    }
+
+    expect((store.dispatch as jest.Mock).mock.calls.length).toEqual(dispatchCountAfterMount);
+  });
+
+  it('still dispatches when the forecast predictions genuinely change', () => {
+    const store = mockStore(storeState);
+    store.dispatch = jest.fn(() => Promise.resolve({}));
+
+    const forecastA = { molecule: { id: 1 }, predictions: { running: false } };
+    const { rerender } = render(
+      <Provider store={store}>
+        <ForecastViewer {...baseProps} forecast={forecastA} />
+      </Provider>,
+    );
+    const dispatchCountAfterMount = (store.dispatch as jest.Mock).mock.calls.length;
+
+    const forecastB = { molecule: { id: 1 }, predictions: { running: true, refreshed: true } };
+    rerender(
+      <Provider store={store}>
+        <ForecastViewer {...baseProps} forecast={forecastB} />
+      </Provider>,
+    );
+
+    expect((store.dispatch as jest.Mock).mock.calls.length).toBeGreaterThan(dispatchCountAfterMount);
+  });
+});

--- a/src/__tests__/units/layer_init_multi_curve_loop.test.tsx
+++ b/src/__tests__/units/layer_init_multi_curve_loop.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import LayerInit from '../../layer_init';
+import { CURVE } from '../../constants/action_type';
+import { LIST_LAYOUT } from '../../constants/list_layout';
+
+jest.mock('../../components/hplc_viewer', () => () => (
+  <div data-testid="hplc-viewer" />
+));
+
+jest.mock('../../components/multi_jcamps_viewer', () => () => (
+  <div data-testid="multi-jcamps-viewer" />
+));
+
+jest.mock('../../layer_prism', () => () => (
+  <div data-testid="layer-prism" />
+));
+
+const mockStore = configureStore([]);
+
+const storeState = {
+  layout: LIST_LAYOUT.CYCLIC_VOLTAMMETRY,
+  curve: { listCurves: [], curveIdx: 0 },
+  hplcMs: {},
+};
+
+const baseProps = {
+  others: { something: true },
+  cLabel: '',
+  xLabel: '',
+  yLabel: '',
+  molSvg: '',
+  editorOnly: true,
+  exactMass: '',
+  forecast: {},
+  operations: [],
+  descriptions: [],
+  canChangeDescription: false,
+  onDescriptionChanged: () => {},
+};
+
+// Two distinct entities that are equivalent in content (same layout/title/x data)
+// but built fresh each time - mimicking a host re-render that rebuilds arrays
+// via `.map()`/object literals on every render without changing what they mean.
+const buildEquivalentMultiEntities = () => ([
+  {
+    layout: LIST_LAYOUT.CYCLIC_VOLTAMMETRY,
+    title: 'curve-a',
+    spectra: [{ data: [{ x: [1, 2, 3], y: [1, 2, 3] }] }],
+  },
+  {
+    layout: LIST_LAYOUT.CYCLIC_VOLTAMMETRY,
+    title: 'curve-b',
+    spectra: [{ data: [{ x: [4, 5, 6], y: [4, 5, 6] }] }],
+  },
+]);
+
+describe('LayerInit — multi-curve host prop churn does not re-dispatch SET_ALL_CURVES', () => {
+  it('does not dispatch SET_ALL_CURVES again when re-rendered with content-equivalent (but new-reference) multiEntities/entity', () => {
+    const store = mockStore(storeState);
+    const entityA = buildEquivalentMultiEntities()[0];
+    const multiEntitiesA = buildEquivalentMultiEntities();
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={entityA} multiEntities={multiEntitiesA} />
+      </Provider>,
+    );
+
+    const setAllCurvesCountAfterMount = store.getActions()
+      .filter((a) => a.type === CURVE.SET_ALL_CURVES).length;
+    expect(setAllCurvesCountAfterMount).toBe(1);
+
+    // Simulate a host re-render that rebuilds equivalent-but-new entity/array
+    // references, as described in issue #329.
+    for (let i = 0; i < 5; i += 1) {
+      const entityB = buildEquivalentMultiEntities()[0];
+      const multiEntitiesB = buildEquivalentMultiEntities();
+      rerender(
+        <Provider store={store}>
+          <LayerInit {...baseProps} entity={entityB} multiEntities={multiEntitiesB} />
+        </Provider>,
+      );
+    }
+
+    const setAllCurvesCountAfterRerenders = store.getActions()
+      .filter((a) => a.type === CURVE.SET_ALL_CURVES).length;
+    expect(setAllCurvesCountAfterRerenders).toBe(1);
+  });
+
+  it('still dispatches SET_ALL_CURVES when multiEntities meaningfully changes', () => {
+    const store = mockStore(storeState);
+    const [entityA, entityB] = buildEquivalentMultiEntities();
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={entityA} multiEntities={[entityA, entityB]} />
+      </Provider>,
+    );
+
+    const newEntity = {
+      layout: LIST_LAYOUT.CYCLIC_VOLTAMMETRY,
+      title: 'curve-c',
+      spectra: [{ data: [{ x: [7, 8, 9], y: [7, 8, 9] }] }],
+    };
+
+    rerender(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={entityA} multiEntities={[entityA, entityB, newEntity]} />
+      </Provider>,
+    );
+
+    const setAllCurvesCount = store.getActions()
+      .filter((a) => a.type === CURVE.SET_ALL_CURVES).length;
+    expect(setAllCurvesCount).toBe(2);
+  });
+});

--- a/src/__tests__/units/layer_init_multi_curve_loop.test.tsx
+++ b/src/__tests__/units/layer_init_multi_curve_loop.test.tsx
@@ -119,3 +119,63 @@ describe('LayerInit — multi-curve host prop churn does not re-dispatch SET_ALL
     expect(setAllCurvesCount).toBe(2);
   });
 });
+
+// An id-only signature collides for these: `idDt` is a DATASET-scope key shared
+// by every curve of an LC/MS group, so it stays constant while the host swaps in
+// a genuinely different page. Digesting the content is what tells them apart.
+const buildLcMsPage = (yValues: number[]) => ({
+  idDt: 'dataset-42',
+  layout: LIST_LAYOUT.CYCLIC_VOLTAMMETRY,
+  title: 'curve-a',
+  spectra: [{ data: [{ x: [1, 2, 3], y: yValues }] }],
+});
+
+describe('LayerInit — a changed entity is still detected when its id stays constant', () => {
+  it('dispatches SET_ALL_CURVES when multiEntities content changes under a constant idDt', () => {
+    const store = mockStore(storeState);
+    const pageA = buildLcMsPage([1, 2, 3]);
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={pageA} multiEntities={[pageA]} />
+      </Provider>,
+    );
+
+    expect(store.getActions().filter((a) => a.type === CURVE.SET_ALL_CURVES).length).toBe(1);
+
+    // Same idDt, same x grid and same array lengths - only the measured y values
+    // differ, exactly as a new LC/MS retention time (or an IR sample resampled
+    // onto the standardized wavenumber grid) arrives.
+    const pageB = buildLcMsPage([100, 200, 300]);
+
+    rerender(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={pageB} multiEntities={[pageB]} />
+      </Provider>,
+    );
+
+    expect(store.getActions().filter((a) => a.type === CURVE.SET_ALL_CURVES).length).toBe(2);
+  });
+
+  it('still suppresses the re-dispatch for a content-equivalent rebuild carrying that same id', () => {
+    const store = mockStore(storeState);
+    const pageA = buildLcMsPage([1, 2, 3]);
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={pageA} multiEntities={[pageA]} />
+      </Provider>,
+    );
+
+    for (let i = 0; i < 5; i += 1) {
+      const rebuilt = buildLcMsPage([1, 2, 3]);
+      rerender(
+        <Provider store={store}>
+          <LayerInit {...baseProps} entity={rebuilt} multiEntities={[rebuilt]} />
+        </Provider>,
+      );
+    }
+
+    expect(store.getActions().filter((a) => a.type === CURVE.SET_ALL_CURVES).length).toBe(1);
+  });
+});

--- a/src/__tests__/units/layer_prism_single_curve_loop.test.tsx
+++ b/src/__tests__/units/layer_prism_single_curve_loop.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import rootReducer from '../../reducers/index';
+import rootSaga from '../../sagas/index';
+import LayerInit from '../../layer_init';
+import { ExtractJcamp } from '../../helpers/chem';
+import irJcamp from '../fixtures/ir_jcamp';
+
+// Real reducers + real saga middleware + the real (unmocked) LayerInit ->
+// LayerPrism -> Content -> ForecastViewer -> ViewerLine chain, per the
+// "Maximum update depth exceeded" reports on issue #329. Only the D3/SVG
+// painting layer is stubbed (jsdom has no real layout engine for it) -
+// componentDidMount/componentDidUpdate/normChange all run for real.
+jest.mock('../../components/common/draw', () => ({
+  drawMain: jest.fn(),
+  drawLabel: jest.fn(),
+  drawDisplay: jest.fn(),
+  drawDestroy: jest.fn(),
+  drawArrowOnCurve: jest.fn(),
+}));
+
+jest.mock('../../components/d3_line/line_focus', () => ({
+  __esModule: true,
+  default: class MockLineFocus {
+    create() {}
+
+    update() {}
+  },
+}));
+
+const baseProps = {
+  others: { others: [], addOthersCb: false },
+  cLabel: '',
+  xLabel: '',
+  yLabel: '',
+  molSvg: '',
+  editorOnly: true,
+  exactMass: '',
+  forecast: { molecule: {}, predictions: {} },
+  operations: [],
+  descriptions: [],
+  canChangeDescription: false,
+  onDescriptionChanged: () => {},
+  multiEntities: [],
+  entityFileNames: [],
+};
+
+const buildStoreWithActionLog = () => {
+  const actionLog: string[] = [];
+  const logMiddleware = () => (next: any) => (action: any) => {
+    actionLog.push(action.type);
+    // A real infinite loop would keep growing this well past any sane
+    // count; fail loudly instead of letting the test hang.
+    if (actionLog.length > 500) {
+      throw new Error(`Dispatch runaway detected: ${actionLog.slice(-20).join(', ')} ... (${actionLog.length} total)`);
+    }
+    return next(action);
+  };
+  const sagaMiddleware = createSagaMiddleware();
+  const store = createStore(rootReducer, applyMiddleware(logMiddleware, sagaMiddleware));
+  sagaMiddleware.run(rootSaga);
+  return { store, actionLog };
+};
+
+describe('LayerPrism/ViewerLine single-curve session dispatch behavior (issue #329 follow-up)', () => {
+  it('mounts a single IR entity with a small, bounded number of dispatches', () => {
+    const { store, actionLog } = buildStoreWithActionLog();
+    const entity: any = ExtractJcamp(irJcamp);
+
+    render(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={entity} />
+      </Provider>,
+    );
+
+    expect(actionLog.length).toBeLessThan(20);
+  });
+
+  it('re-rendering with fresh-but-equivalent entity/forecast (host churn) stays bounded per render, not exponential', () => {
+    const { store, actionLog } = buildStoreWithActionLog();
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={ExtractJcamp(irJcamp)} forecast={{ molecule: {}, predictions: {} }} />
+      </Provider>,
+    );
+    const afterMount = actionLog.length;
+
+    for (let i = 0; i < 20; i += 1) {
+      rerender(
+        <Provider store={store}>
+          <LayerInit
+            {...baseProps}
+            entity={ExtractJcamp(irJcamp)}
+            forecast={{ molecule: {}, predictions: {} }}
+          />
+        </Provider>,
+      );
+    }
+
+    // ViewerLine.normChange still resets on every render (feature is
+    // rebuilt fresh by the unmemoized extractParams call in layer_prism.js),
+    // so each churned re-render adds a small constant number of dispatches -
+    // this is wasteful but bounded, not a cycle. ForecastViewer no longer
+    // contributes to this count (fixed: compares forecast by content).
+    const perRenderDispatches = (actionLog.length - afterMount) / 20;
+    expect(perRenderDispatches).toBeLessThanOrEqual(5);
+  });
+});

--- a/src/__tests__/units/layer_prism_single_curve_loop.test.tsx
+++ b/src/__tests__/units/layer_prism_single_curve_loop.test.tsx
@@ -10,27 +10,23 @@ import rootSaga from '../../sagas/index';
 import LayerInit from '../../layer_init';
 import { ExtractJcamp } from '../../helpers/chem';
 import irJcamp from '../fixtures/ir_jcamp';
+import nmr13cJcamp from '../fixtures/nmr13c_jcamp';
 
 // Real reducers + real saga middleware + the real (unmocked) LayerInit ->
 // LayerPrism -> Content -> ForecastViewer -> ViewerLine chain, per the
 // "Maximum update depth exceeded" reports on issue #329. Only the D3/SVG
 // painting layer is stubbed (jsdom has no real layout engine for it) -
-// componentDidMount/componentDidUpdate/normChange all run for real.
+// componentDidMount/componentDidUpdate/normChange, and the real LineFocus
+// class, all run for real. (An earlier version of this test mocked
+// LineFocus away entirely, which was harmless here - LineFocus never
+// dispatches outside of click handlers - but keeping it real removes any
+// doubt for a case this precise.)
 jest.mock('../../components/common/draw', () => ({
   drawMain: jest.fn(),
   drawLabel: jest.fn(),
   drawDisplay: jest.fn(),
   drawDestroy: jest.fn(),
   drawArrowOnCurve: jest.fn(),
-}));
-
-jest.mock('../../components/d3_line/line_focus', () => ({
-  __esModule: true,
-  default: class MockLineFocus {
-    create() {}
-
-    update() {}
-  },
 }));
 
 const baseProps = {
@@ -81,34 +77,55 @@ describe('LayerPrism/ViewerLine single-curve session dispatch behavior (issue #3
     expect(actionLog.length).toBeLessThan(20);
   });
 
-  it('re-rendering with fresh-but-equivalent entity/forecast (host churn) stays bounded per render, not exponential', () => {
+  // The exact reproduction from issue #329's live dispatch-logged trace: a
+  // single 13C NMR entity (curveIdx 0, not multi-curve), re-rendered
+  // repeatedly with a fresh-but-content-equal entity object each time (as a
+  // host with no memoization on its side does). Before the layer_prism.js
+  // fix, this produced an unbounded RESET_ALL/RESET_SHIFT ping-pong (2
+  // dispatches per re-render, forever, as the host kept re-rendering) -
+  // ViewerLine.normChange dispatches MANAGER.RESETALL whenever its `feature`
+  // prop's reference changes, and layer_prism.js rebuilt `feature` fresh via
+  // an unmemoized extractParams() call on every render, regardless of
+  // whether entity/thresSt/scanSt actually changed content.
+  it('re-rendering with fresh-but-equivalent 13C entity (host churn) dispatches nothing further', () => {
     const { store, actionLog } = buildStoreWithActionLog();
+    const build = () => ExtractJcamp(nmr13cJcamp);
 
     const { rerender } = render(
       <Provider store={store}>
-        <LayerInit {...baseProps} entity={ExtractJcamp(irJcamp)} forecast={{ molecule: {}, predictions: {} }} />
+        <LayerInit {...baseProps} entity={build()} />
       </Provider>,
     );
     const afterMount = actionLog.length;
 
-    for (let i = 0; i < 20; i += 1) {
+    for (let i = 0; i < 40; i += 1) {
       rerender(
         <Provider store={store}>
-          <LayerInit
-            {...baseProps}
-            entity={ExtractJcamp(irJcamp)}
-            forecast={{ molecule: {}, predictions: {} }}
-          />
+          <LayerInit {...baseProps} entity={build()} />
         </Provider>,
       );
     }
 
-    // ViewerLine.normChange still resets on every render (feature is
-    // rebuilt fresh by the unmemoized extractParams call in layer_prism.js),
-    // so each churned re-render adds a small constant number of dispatches -
-    // this is wasteful but bounded, not a cycle. ForecastViewer no longer
-    // contributes to this count (fixed: compares forecast by content).
-    const perRenderDispatches = (actionLog.length - afterMount) / 20;
-    expect(perRenderDispatches).toBeLessThanOrEqual(5);
+    expect(actionLog.length).toEqual(afterMount);
+  });
+
+  it('still resets when the entity genuinely changes', () => {
+    const { store, actionLog } = buildStoreWithActionLog();
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={ExtractJcamp(nmr13cJcamp)} />
+      </Provider>,
+    );
+    const afterMount = actionLog.length;
+
+    rerender(
+      <Provider store={store}>
+        <LayerInit {...baseProps} entity={ExtractJcamp(irJcamp)} />
+      </Provider>,
+    );
+
+    expect(actionLog.length).toBeGreaterThan(afterMount);
+    expect(actionLog.slice(afterMount)).toContain('RESET_ALL');
   });
 });

--- a/src/__tests__/units/layer_prism_stale_cache.test.tsx
+++ b/src/__tests__/units/layer_prism_stale_cache.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import LayerPrism from '../../layer_prism';
+import { LIST_LAYOUT } from '../../constants/list_layout';
+import { LIST_UI_VIEWER_TYPE } from '../../constants/list_ui';
+
+// Capture whatever `feature`/`topic` LayerPrism actually hands down, without
+// exercising the real D3/panel rendering machinery.
+const captured: any[] = [];
+jest.mock('../../layer_content', () => (props: any) => {
+  captured.push({ topic: props.topic, feature: props.feature });
+  return <div data-testid="layer-content" />;
+});
+jest.mock('../../components/cmd_bar/index', () => () => <div />);
+jest.mock('../../components/panel/index', () => () => <div />);
+
+const mockStore = configureStore([]);
+
+const storeState = {
+  scan: {},
+  threshold: { list: [{ isEdit: true, value: false, upper: false, lower: false }] },
+  ui: { viewer: LIST_UI_VIEWER_TYPE.SPECTRUM },
+  curve: { curveIdx: 0 },
+  integration: { present: { integrations: [] } },
+};
+
+const baseProps = {
+  cLabel: '',
+  xLabel: '',
+  yLabel: '',
+  molSvg: '',
+  editorOnly: true,
+  exactMass: '',
+  forecast: {},
+  operations: [],
+  descriptions: [],
+  canChangeDescription: false,
+};
+
+// Two genuinely different IR-layout entities sharing an IDENTICAL x grid
+// (as any instrument that resamples every measurement onto the same
+// standardized wavenumber axis would produce) but different y (measured)
+// data - the exact class of collision an x-only, first-spectrum-only
+// signature cannot distinguish (see issue #329's blank-chart regression).
+const buildEntity = (yValues: number[]) => ({
+  layout: LIST_LAYOUT.IR,
+  title: '',
+  spectra: [{ data: [{ x: [4000, 3000, 2000], y: yValues }] }],
+  features: {
+    autoPeak: {
+      data: [{ x: [4000, 3000, 2000], y: yValues }],
+      maxY: Math.max(...yValues),
+    },
+  },
+});
+
+describe('LayerPrism does not serve stale cached data for a different entity with the same x grid (issue #329)', () => {
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  it('renders the second entity own data, not the first entity cached feature/topic', () => {
+    const store = mockStore(storeState);
+    const entityA = buildEntity([1, 2, 3]);
+    const entityB = buildEntity([100, 200, 300]);
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerPrism {...baseProps} entity={entityA} />
+      </Provider>,
+    );
+    expect(captured[captured.length - 1].topic.y).toEqual([1, 2, 3]);
+
+    rerender(
+      <Provider store={store}>
+        <LayerPrism {...baseProps} entity={entityB} />
+      </Provider>,
+    );
+
+    expect(captured[captured.length - 1].topic.y).toEqual([100, 200, 300]);
+    expect(captured[captured.length - 1].feature.data[0].y).toEqual([100, 200, 300]);
+  });
+
+  it('still reuses the cached result for a re-render with a fresh-but-content-equal entity', () => {
+    const store = mockStore(storeState);
+    const entityA1 = buildEntity([1, 2, 3]);
+    const entityA2 = buildEntity([1, 2, 3]);
+
+    const { rerender } = render(
+      <Provider store={store}>
+        <LayerPrism {...baseProps} entity={entityA1} />
+      </Provider>,
+    );
+    const firstFeature = captured[captured.length - 1].feature;
+
+    rerender(
+      <Provider store={store}>
+        <LayerPrism {...baseProps} entity={entityA2} />
+      </Provider>,
+    );
+
+    expect(captured[captured.length - 1].feature).toBe(firstFeature);
+  });
+});

--- a/src/__tests__/units/reducers/reducer_edit_peak.test.tsx
+++ b/src/__tests__/units/reducers/reducer_edit_peak.test.tsx
@@ -93,4 +93,13 @@ describe('Test redux reducer for edit peak', () => {
     expect(newState.selectedIdx).toEqual(1)
     expect(newState.peaks[1]).toEqual({pos: [], neg: [{x: 1, y: 2}]})
   })
+
+  it('Clear all peaks does not throw when peaks[curveIdx] does not exist yet', () => {
+    action.type = EDITPEAK.CLEAR_ALL
+    action.payload = { curveIdx: 2, dataPeaks: [{x: 5, y: 6}] }
+    peaksState = { peaks: [{pos: [], neg: []}], selectedIdx: 0 }
+    const newState = editPeakReducer(peaksState, action)
+    expect(newState.selectedIdx).toEqual(2)
+    expect(newState.peaks[2]).toEqual({prevOffset: 0, pos: [], neg: [{x: 5, y: 6}]})
+  })
 })

--- a/src/__tests__/units/reducers/reducer_edit_peak.test.tsx
+++ b/src/__tests__/units/reducers/reducer_edit_peak.test.tsx
@@ -81,4 +81,16 @@ describe('Test redux reducer for edit peak', () => {
     const newState = editPeakReducer(peaksState, action)
     expect(newState).toEqual(expectedValue)
   })
+
+  it('Clear all peaks moves selectedIdx to the cleared curve, like the other peak mutators', () => {
+    action.type = EDITPEAK.CLEAR_ALL
+    action.payload = { curveIdx: 1, dataPeaks: [] }
+    peaksState = {
+      peaks: [{pos: [], neg: []}, {pos: [{x: 1, y: 2}], neg: []}],
+      selectedIdx: 0,
+    }
+    const newState = editPeakReducer(peaksState, action)
+    expect(newState.selectedIdx).toEqual(1)
+    expect(newState.peaks[1]).toEqual({pos: [], neg: [{x: 1, y: 2}]})
+  })
 })

--- a/src/components/cmd_bar/03_peak.js
+++ b/src/components/cmd_bar/03_peak.js
@@ -46,7 +46,7 @@ const Peak = ({
     if (layoutSt === LIST_LAYOUT.LC_MS) {
       clearAllPeaksHplcMsAct();
     } else {
-      const dataPeaks = extractAutoPeaks(feature, thresSt, shiftSt, layoutSt);
+      const dataPeaks = extractAutoPeaks(feature, thresSt, shiftSt, layoutSt, curveIdx);
       clearAllPeaksAct({ curveIdx, dataPeaks });
     }
   };

--- a/src/components/forecast_viewer.js
+++ b/src/components/forecast_viewer.js
@@ -13,6 +13,24 @@ import { initForecastStatus } from '../actions/forecast';
 import { setUiViewerType } from '../actions/ui';
 import { LIST_UI_VIEWER_TYPE } from '../constants/list_ui';
 
+// A host that rebuilds `forecast` as a fresh object literal on every render
+// (no memoization on its side) must not make ForecastViewer re-dispatch
+// FORECAST.INIT_STATUS on every single re-render regardless of whether the
+// prediction data actually changed - only `predictions`/`molecule` drive
+// initForecastReducer's effect, so compare those by content instead of the
+// whole `forecast` object by reference.
+const forecastSignature = (forecast) => {
+  if (!forecast || typeof forecast !== 'object') return 'none';
+  const { predictions, molecule } = forecast;
+  try {
+    return JSON.stringify({ predictions, molecule });
+  } catch (e) {
+    // Unstringifiable content (e.g. a circular structure): never treat as
+    // equal, so we fall back to the old always-refresh behavior.
+    return null;
+  }
+};
+
 const styles = () => ({
   root: {
     flexGrow: 1,
@@ -39,10 +57,9 @@ class ForecastViewer extends React.Component {
 
   componentDidUpdate(prevProps) {
     const { forecast } = this.props;
-
-    const prevForecast = forecast;
-    const nextForecast = prevProps.forecast;
-    if (prevForecast !== nextForecast) {
+    const prevSig = forecastSignature(prevProps.forecast);
+    const nextSig = forecastSignature(forecast);
+    if (prevSig === null || nextSig === null || prevSig !== nextSig) {
       this.initForecastReducer();
     }
   }

--- a/src/helpers/entity_signature.js
+++ b/src/helpers/entity_signature.js
@@ -1,0 +1,61 @@
+// Content fingerprints for host-supplied entities.
+//
+// Hosts routinely rebuild `entity` / `multiEntities` as fresh object literals on
+// every render, so reference equality cannot answer "did the data actually
+// change?". Answering it with `!==` is what cascaded into React's "Maximum
+// update depth exceeded" in issue #329. These helpers answer it by content
+// instead.
+//
+// Entities carry large spectral arrays, so nothing here stringifies one
+// wholesale; each data block is reduced to length/first/last per axis.
+
+// Digest of a single `{ x, y }` data block, on BOTH axes.
+const dataBlockDigest = (data0) => {
+  if (!data0) return 'none';
+  const xs = Array.isArray(data0.x) ? data0.x : [];
+  const ys = Array.isArray(data0.y) ? data0.y : [];
+  return `${xs.length}:${xs[0]}:${xs[xs.length - 1]}:${ys.length}:${ys[0]}:${ys[ys.length - 1]}`;
+};
+
+// A stable content signature for one entity.
+//
+// Three properties this digest must have, each learned from a way an easier
+// signature collides between two genuinely different entities:
+//
+//  - It must not key on the id alone. `idDt` is a DATASET-scope key shared by
+//    every curve of an LC/MS group (see reducer_hplc_ms/hydrate.js's
+//    `lcmsDatasetKey`), so an id-only signature stays constant for a whole
+//    session - a host answering `onLcmsPageRequest` with a new retention time
+//    would look unchanged. The id is folded in as one component, never as a
+//    short-circuit.
+//  - It must digest every `spectra` block, not just the first: an MS-layout
+//    entity's displayed topic comes from `spectra[scanIdx]` (chosen by
+//    getScanIdx), not `spectra[0]`.
+//  - It must digest both axes. Many instrument types - IR in particular -
+//    resample every measurement onto the same standardized wavenumber grid, so
+//    two completely different samples share an identical x length/head/tail
+//    while only their measured y values differ.
+//
+// The feature blocks extractParams itself reads (autoPeak/editPeak) are folded
+// in too, so a mismatch anywhere in what extractParams consumes shows up here.
+const entitySignature = (e) => {
+  if (!e) return 'none';
+  const id = e.idDt ?? e.id ?? e.datasetId;
+  const spectraDigest = Array.isArray(e.spectra)
+    ? e.spectra.map((s) => dataBlockDigest(s?.data?.[0])).join(';')
+    : 'none';
+  const features = (e.features && typeof e.features === 'object' && !Array.isArray(e.features))
+    ? e.features
+    : {};
+  const autoDigest = dataBlockDigest(features.autoPeak?.data?.[0]);
+  const editDigest = dataBlockDigest(features.editPeak?.data?.[0]);
+  return `${e.layout || ''}|${e.title || ''}|id:${id ?? ''}|sp:${spectraDigest}|auto:${autoDigest}|edit:${editDigest}`;
+};
+
+// Signature for a list of entities (`multiEntities`).
+const multiEntitiesSignature = (entities) => {
+  if (!Array.isArray(entities)) return 'none';
+  return `len:${entities.length}|${entities.map((e) => entitySignature(e)).join('||')}`;
+};
+
+export { dataBlockDigest, entitySignature, multiEntitiesSignature };

--- a/src/layer_init.js
+++ b/src/layer_init.js
@@ -42,6 +42,11 @@ class LayerInit extends React.Component {
     return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
   }
 
+  static multiEntitiesSignature(entities) {
+    if (!Array.isArray(entities)) return 'none';
+    return `len:${entities.length}|${entities.map((e) => LayerInit.entitySignature(e)).join('||')}`;
+  }
+
   constructor(props) {
     super(props);
 
@@ -63,22 +68,25 @@ class LayerInit extends React.Component {
     const {
       others, multiEntities, entity, operations,
     } = this.props;
-    this.normChange(prevProps);
-    if (prevProps.operations !== operations || prevProps.entity !== entity) {
+    const entityChanged = LayerInit.entitySignature(prevProps.entity)
+      !== LayerInit.entitySignature(entity);
+    this.normChange(prevProps, entityChanged);
+    if (prevProps.operations !== operations || entityChanged) {
       this.initReducer();
     }
     if (prevProps.others !== others) {
       this.updateOthers();
     }
-    if (prevProps.multiEntities !== multiEntities
-      || prevProps.entity !== entity) {
+    if (LayerInit.multiEntitiesSignature(prevProps.multiEntities)
+      !== LayerInit.multiEntitiesSignature(multiEntities)
+      || entityChanged) {
       this.updateMultiEntities();
     }
   }
 
-  normChange(prevProps) {
+  normChange(prevProps, entityChanged) {
     const { entity, multiEntities, clearHplcMsStateAct } = this.props;
-    if (prevProps.entity !== entity) {
+    if (entityChanged) {
       const prevIsLcms = Format.isLCMsLayout(prevProps.entity?.layout);
       const nextIsLcms = Format.isLCMsLayout(entity?.layout);
       const lcmsSessionActive = prevIsLcms && nextIsLcms

--- a/src/layer_init.js
+++ b/src/layer_init.js
@@ -16,6 +16,7 @@ import { updateMetaPeaks, updateDSCMetaData } from './actions/meta';
 import { addOthers } from './actions/jcamp';
 import LayerPrism from './layer_prism';
 import Format from './helpers/format';
+import { entitySignature, multiEntitiesSignature } from './helpers/entity_signature';
 import { getLcMsInfo, isLcMsGroup } from './helpers/extractEntityLCMS';
 import { reconcileLcMsTimeAxes } from './features/lc-ms/entities/timeAxis';
 import MultiJcampsViewer from './components/multi_jcamps_viewer';
@@ -27,26 +28,6 @@ const styles = () => ({
 });
 
 class LayerInit extends React.Component {
-  static entitySignature(e) {
-    if (!e) return 'none';
-    const id = e.idDt ?? e.id ?? e.datasetId;
-    if (id != null && id !== '') return `id:${id}`;
-    const firstFeature = (Array.isArray(e.features) ? e.features[0] : null)
-      || (Array.isArray(e.spectra) ? e.spectra[0] : null)
-      || null;
-    const data0 = firstFeature?.data?.[0];
-    const xs = data0?.x;
-    const xLen = Array.isArray(xs) ? xs.length : 0;
-    const xHead = Array.isArray(xs) && xs.length > 0 ? xs[0] : '';
-    const xTail = Array.isArray(xs) && xs.length > 0 ? xs[xs.length - 1] : '';
-    return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
-  }
-
-  static multiEntitiesSignature(entities) {
-    if (!Array.isArray(entities)) return 'none';
-    return `len:${entities.length}|${entities.map((e) => LayerInit.entitySignature(e)).join('||')}`;
-  }
-
   constructor(props) {
     super(props);
 
@@ -68,8 +49,8 @@ class LayerInit extends React.Component {
     const {
       others, multiEntities, entity, operations,
     } = this.props;
-    const entityChanged = LayerInit.entitySignature(prevProps.entity)
-      !== LayerInit.entitySignature(entity);
+    const entityChanged = entitySignature(prevProps.entity)
+      !== entitySignature(entity);
     this.normChange(prevProps, entityChanged);
     if (prevProps.operations !== operations || entityChanged) {
       this.initReducer();
@@ -77,8 +58,8 @@ class LayerInit extends React.Component {
     if (prevProps.others !== others) {
       this.updateOthers();
     }
-    if (LayerInit.multiEntitiesSignature(prevProps.multiEntities)
-      !== LayerInit.multiEntitiesSignature(multiEntities)
+    if (multiEntitiesSignature(prevProps.multiEntities)
+      !== multiEntitiesSignature(multiEntities)
       || entityChanged) {
       this.updateMultiEntities();
     }
@@ -93,8 +74,8 @@ class LayerInit extends React.Component {
         && Array.isArray(multiEntities)
         && isLcMsGroup(multiEntities);
       if ((prevIsLcms || nextIsLcms) && !lcmsSessionActive) {
-        const prevSig = LayerInit.entitySignature(prevProps.entity);
-        const nextSig = LayerInit.entitySignature(entity);
+        const prevSig = entitySignature(prevProps.entity);
+        const nextSig = entitySignature(entity);
         if (prevSig !== nextSig) {
           clearHplcMsStateAct();
         }

--- a/src/layer_prism.js
+++ b/src/layer_prism.js
@@ -34,22 +34,42 @@ const getThresholdState = (state) => {
 // whenever `feature`'s reference changes, and that cascades into a fresh
 // state.threshold reference, causing LayerPrism to re-render and rebuild
 // `feature` again, and so on, once per host render. Since `entity` can carry
-// large spectral data arrays, avoid stringifying it wholesale; use the same
-// lightweight id/shape signature LayerInit already uses to detect "same
-// dataset, new reference".
+// large spectral data arrays, avoid stringifying it wholesale; digest only
+// each data block's length/first/last on BOTH axes.
+//
+// Unlike LayerInit's own (lower-stakes) entitySignature helper - which only
+// gates whether to re-dispatch a redux init action, so a false "unchanged"
+// merely skips a re-init - this signature directly gates what actually gets
+// RENDERED, so it must not collide between two genuinely different entities.
+// An X-only, first-spectrum-only digest is not safe enough for that: many
+// instrument types (IR in particular) resample every measurement onto the
+// same standardized wavenumber grid, so two completely different samples
+// can share identical x length/head/tail while their y (measured) values
+// differ - and an entity's actually-displayed data is not always its first
+// spectra entry (an MS-layout entity's topic comes from spectra[scanIdx],
+// selected by getScanIdx, not spectra[0]). Digest every spectrum block (not
+// just the first) and both axes, plus the feature blocks extractParams
+// itself reads (autoPeak/editPeak), so a mismatch anywhere in what
+// extractParams actually consumes invalidates the cache.
+const dataBlockDigest = (data0) => {
+  if (!data0) return 'none';
+  const xs = Array.isArray(data0.x) ? data0.x : [];
+  const ys = Array.isArray(data0.y) ? data0.y : [];
+  return `${xs.length}:${xs[0]}:${xs[xs.length - 1]}:${ys.length}:${ys[0]}:${ys[ys.length - 1]}`;
+};
+
 const entitySignature = (e) => {
   if (!e) return 'none';
   const id = e.idDt ?? e.id ?? e.datasetId;
-  if (id != null && id !== '') return `id:${id}`;
-  const firstFeature = (Array.isArray(e.features) ? e.features[0] : null)
-    || (Array.isArray(e.spectra) ? e.spectra[0] : null)
-    || null;
-  const data0 = firstFeature?.data?.[0];
-  const xs = data0?.x;
-  const xLen = Array.isArray(xs) ? xs.length : 0;
-  const xHead = Array.isArray(xs) && xs.length > 0 ? xs[0] : '';
-  const xTail = Array.isArray(xs) && xs.length > 0 ? xs[xs.length - 1] : '';
-  return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
+  const spectraDigest = Array.isArray(e.spectra)
+    ? e.spectra.map((s) => dataBlockDigest(s?.data?.[0])).join(';')
+    : 'none';
+  const features = (e.features && typeof e.features === 'object' && !Array.isArray(e.features))
+    ? e.features
+    : {};
+  const autoDigest = dataBlockDigest(features.autoPeak?.data?.[0]);
+  const editDigest = dataBlockDigest(features.editPeak?.data?.[0]);
+  return `${e.layout || ''}|${e.title || ''}|id:${id ?? ''}|sp:${spectraDigest}|auto:${autoDigest}|edit:${editDigest}`;
 };
 
 const useExtractedParams = (entity, thresSt, scanSt) => {

--- a/src/layer_prism.js
+++ b/src/layer_prism.js
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-object-spread, default-param-last,
 react/function-component-definition, react/require-default-props
 */
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -27,6 +27,40 @@ const getThresholdState = (state) => {
   return thresholdList[curveIdx] || thresholdList[0] || {};
 };
 
+// A host that rebuilds `entity` as a fresh object literal on every render
+// (no memoization on its side) must not hand ViewerLine (via extractParams'
+// `feature`) a brand-new object every single time regardless of whether the
+// underlying data changed - ViewerLine.normChange dispatches MANAGER.RESETALL
+// whenever `feature`'s reference changes, and that cascades into a fresh
+// state.threshold reference, causing LayerPrism to re-render and rebuild
+// `feature` again, and so on, once per host render. Since `entity` can carry
+// large spectral data arrays, avoid stringifying it wholesale; use the same
+// lightweight id/shape signature LayerInit already uses to detect "same
+// dataset, new reference".
+const entitySignature = (e) => {
+  if (!e) return 'none';
+  const id = e.idDt ?? e.id ?? e.datasetId;
+  if (id != null && id !== '') return `id:${id}`;
+  const firstFeature = (Array.isArray(e.features) ? e.features[0] : null)
+    || (Array.isArray(e.spectra) ? e.spectra[0] : null)
+    || null;
+  const data0 = firstFeature?.data?.[0];
+  const xs = data0?.x;
+  const xLen = Array.isArray(xs) ? xs.length : 0;
+  const xHead = Array.isArray(xs) && xs.length > 0 ? xs[0] : '';
+  const xTail = Array.isArray(xs) && xs.length > 0 ? xs[xs.length - 1] : '';
+  return `sig:${e.layout || ''}|${e.title || ''}|${xLen}|${xHead}|${xTail}`;
+};
+
+const useExtractedParams = (entity, thresSt, scanSt) => {
+  const signature = `${entitySignature(entity)}|${JSON.stringify(thresSt)}|${JSON.stringify(scanSt)}`;
+  const cacheRef = useRef(null);
+  if (!cacheRef.current || cacheRef.current.signature !== signature) {
+    cacheRef.current = { signature, result: extractParams(entity, thresSt, scanSt) };
+  }
+  return cacheRef.current.result;
+};
+
 const LayerPrism = ({
   entity, cLabel, xLabel, yLabel, forecast, operations,
   descriptions, molSvg, editorOnly, exactMass,
@@ -35,7 +69,7 @@ const LayerPrism = ({
 }) => {
   const {
     topic, feature, hasEdit, integration: initialIntegration, features,
-  } = extractParams(entity, thresSt, scanSt);
+  } = useExtractedParams(entity, thresSt, scanSt);
   if (!topic) return null;
 
   const curveIdx = (curveSt && Number.isFinite(curveSt.curveIdx)) ? curveSt.curveIdx : 0;

--- a/src/layer_prism.js
+++ b/src/layer_prism.js
@@ -14,6 +14,7 @@ import CmdBar from './components/cmd_bar/index';
 import LayerContent from './layer_content';
 import { LIST_UI_VIEWER_TYPE } from './constants/list_ui';
 import { extractParams } from './helpers/extractParams';
+import { entitySignature } from './helpers/entity_signature';
 import { LIST_HOST_HOOK_CLASS } from './constants/list_graph';
 
 const styles = () => ({
@@ -27,51 +28,18 @@ const getThresholdState = (state) => {
   return thresholdList[curveIdx] || thresholdList[0] || {};
 };
 
-// A host that rebuilds `entity` as a fresh object literal on every render
-// (no memoization on its side) must not hand ViewerLine (via extractParams'
+// A host that rebuilds `entity` as a fresh object literal on every render (no
+// memoization on its side) must not hand ViewerLine (via extractParams'
 // `feature`) a brand-new object every single time regardless of whether the
 // underlying data changed - ViewerLine.normChange dispatches MANAGER.RESETALL
 // whenever `feature`'s reference changes, and that cascades into a fresh
 // state.threshold reference, causing LayerPrism to re-render and rebuild
-// `feature` again, and so on, once per host render. Since `entity` can carry
-// large spectral data arrays, avoid stringifying it wholesale; digest only
-// each data block's length/first/last on BOTH axes.
+// `feature` again, and so on, once per host render.
 //
-// Unlike LayerInit's own (lower-stakes) entitySignature helper - which only
-// gates whether to re-dispatch a redux init action, so a false "unchanged"
-// merely skips a re-init - this signature directly gates what actually gets
-// RENDERED, so it must not collide between two genuinely different entities.
-// An X-only, first-spectrum-only digest is not safe enough for that: many
-// instrument types (IR in particular) resample every measurement onto the
-// same standardized wavenumber grid, so two completely different samples
-// can share identical x length/head/tail while their y (measured) values
-// differ - and an entity's actually-displayed data is not always its first
-// spectra entry (an MS-layout entity's topic comes from spectra[scanIdx],
-// selected by getScanIdx, not spectra[0]). Digest every spectrum block (not
-// just the first) and both axes, plus the feature blocks extractParams
-// itself reads (autoPeak/editPeak), so a mismatch anywhere in what
-// extractParams actually consumes invalidates the cache.
-const dataBlockDigest = (data0) => {
-  if (!data0) return 'none';
-  const xs = Array.isArray(data0.x) ? data0.x : [];
-  const ys = Array.isArray(data0.y) ? data0.y : [];
-  return `${xs.length}:${xs[0]}:${xs[xs.length - 1]}:${ys.length}:${ys[0]}:${ys[ys.length - 1]}`;
-};
-
-const entitySignature = (e) => {
-  if (!e) return 'none';
-  const id = e.idDt ?? e.id ?? e.datasetId;
-  const spectraDigest = Array.isArray(e.spectra)
-    ? e.spectra.map((s) => dataBlockDigest(s?.data?.[0])).join(';')
-    : 'none';
-  const features = (e.features && typeof e.features === 'object' && !Array.isArray(e.features))
-    ? e.features
-    : {};
-  const autoDigest = dataBlockDigest(features.autoPeak?.data?.[0]);
-  const editDigest = dataBlockDigest(features.editPeak?.data?.[0]);
-  return `${e.layout || ''}|${e.title || ''}|id:${id ?? ''}|sp:${spectraDigest}|auto:${autoDigest}|edit:${editDigest}`;
-};
-
+// This signature gates what actually gets RENDERED, so it must not collide
+// between two genuinely different entities; see helpers/entity_signature for
+// why it digests every spectra block on both axes rather than just the first
+// block's x values.
 const useExtractedParams = (entity, thresSt, scanSt) => {
   const signature = `${entitySignature(entity)}|${JSON.stringify(thresSt)}|${JSON.stringify(scanSt)}`;
   const cacheRef = useRef(null);

--- a/src/reducers/reducer_edit_peak.js
+++ b/src/reducers/reducer_edit_peak.js
@@ -153,7 +153,7 @@ const clearAllPeaks = (state, action) => {
   });
   const newPeaks = [...peaks];
   newPeaks[curveIdx] = newSelectedEditPeaks;
-  return Object.assign({}, state, { peaks: newPeaks });
+  return Object.assign({}, state, { peaks: newPeaks, selectedIdx: curveIdx });
 };
 
 const editPeakReducer = (state = initialState, action) => {

--- a/src/reducers/reducer_edit_peak.js
+++ b/src/reducers/reducer_edit_peak.js
@@ -144,7 +144,10 @@ const processShift = (state, action) => {
 const clearAllPeaks = (state, action) => {
   const { curveIdx, dataPeaks } = action.payload;
   const { peaks } = state;
-  const selectedEditPeaks = peaks[curveIdx];
+  let selectedEditPeaks = peaks[curveIdx];
+  if (!selectedEditPeaks) {
+    selectedEditPeaks = defaultEmptyPeaks;
+  }
 
   const { pos } = selectedEditPeaks;
 


### PR DESCRIPTION
## Summary

Fixes #329, whose two halves are both covered here:

**1. Infinite update loop on open.** `LayerInit.componentDidUpdate` decided whether to
re-dispatch `SET_ALL_CURVES` purely by reference equality on host-supplied
`entity`/`multiEntities`. A host that rebuilds those on every render (even with identical
content) triggered a dispatch cascade that eventually tripped React's "Maximum update
depth exceeded". The same reference-equality mistake drove two more re-dispatch loops on
the single-curve path — `ForecastViewer` re-dispatching `FORECAST.INIT_STATUS`, and
`LayerPrism` handing `ViewerLine` a fresh `feature` object on every render. All three now
compare by content.

The shared digest lives in `helpers/entity_signature`. It deliberately does **not** key on
the entity id: `idDt` is a dataset-scope key shared by every curve of an LC/MS group, so an
id-only signature stays constant for a whole session and would mask a genuine page change.
It digests every `spectra` block on both axes, because an MS entity's displayed topic comes
from `spectra[scanIdx]` rather than `spectra[0]`, and because instruments that resample onto
a standardized grid (IR especially) produce different samples sharing an identical x axis.

**2. "Clear All Peaks" didn't persist for curveIdx > 0.** `onClearAll` (`03_peak.js`) called
`extractAutoPeaks(...)` without the `atIndex` argument, so it always used curve 0's
shift/calibration offset. The x-values it blacklisted never matched what gets recomputed at
Save time for any other curve, so the removal silently didn't persist. `curveIdx` is now
passed through, matching `r05_submit_btn.js`. `clearAllPeaks` (`reducer_edit_peak.js`) also
no longer throws when the curve has no peaks entry yet, and updates `selectedIdx` in line
with its sibling mutators.

## Scope note

This branch was rewritten on 2026-09-02 to carry only the commits that resolve #329. Four
commits that had accumulated here — touching `helpers/chem.js`, `helpers/extractParams.js`,
`reducers/reducer_shift.js` and `sagas/index.js` — were moved to
[`329-parked-followups`](https://github.com/ComPlat/react-spectra-editor/tree/329-parked-followups),
because a review found peak-rendering regressions in two of them. All commits keep their
original authorship; the pre-rewrite tip `7b7449c` is preserved at `refs/backup/pr-330-original`.

## Test plan

- [x] `layer_init_multi_curve_loop.test.tsx` — `SET_ALL_CURVES` no longer re-dispatches on
      content-equivalent re-renders, still dispatches when data genuinely changes, and (new)
      still dispatches when content changes under a constant `idDt`. That last case fails
      against the previous id-short-circuit implementation.
- [x] `layer_prism_single_curve_loop.test.tsx` / `layer_prism_stale_cache.test.tsx` —
      no extra dispatches on churn; no stale data across entities sharing an x grid.
- [x] `03_peak.test.js` — `extractAutoPeaks` receives the selected curve's index.
- [x] `reducer_edit_peak.test.tsx` — `selectedIdx` consistency, and no throw on a missing entry.
- [x] Full suite: 752 tests / 83 suites pass.
- [x] `dist/` recompiled and verified byte-identical to a clean rebuild from `src/`.
