### PR TITLE
fix(peaks): follow-ups split out of #330

### DIFF
--- a/dist/helpers/chem.js
+++ b/dist/helpers/chem.js
@@ -619,14 +619,17 @@ const extrSpectraMs = (jcamp, layout) => {
       const pageKey = spectrum.pageValue ?? spectrum.page;
       const peakTable = peakTablesByPage.get(pageKey);
       let selectedPeakTable = null;
-      if (hasPeakData(peakTable?.edit)) {
+      // A saved-but-empty EDIT_PEAK table (e.g. after "Clear All Peaks") must
+      // still win over auto/other, or the deliberately-cleared peaks
+      // resurface as the untouched auto-detected ones on reload.
+      if (peakTable?.edit) {
         selectedPeakTable = peakTable.edit;
       } else if (hasPeakData(peakTable?.auto)) {
         selectedPeakTable = peakTable.auto;
       } else if (hasPeakData(peakTable?.other)) {
         selectedPeakTable = peakTable.other;
       } else {
-        selectedPeakTable = peakTable?.edit || peakTable?.auto || peakTable?.other || null;
+        selectedPeakTable = peakTable?.auto || peakTable?.other || null;
       }
       const normalizedData = needsSecToMin ? scaleSpectrumDataX(spectrum.data, minuteScale) : spectrum.data;
       const mainSpectrum = {

--- a/dist/helpers/chem.js
+++ b/dist/helpers/chem.js
@@ -1010,28 +1010,15 @@ const buildMpyFeature = jcamp => {
 };
 const isPeakTable = s => s.dataType && (s.dataType.includes('PEAKTABLE') || s.dataType.includes('PEAK ASSIGNMENTS'));
 const extrFeaturesNi = (jcamp, layout, peakUp, spectra) => {
-  const nfs = {};
-  const category = jcamp.info.$CSCATEGORY;
-  if (category) {
-    const idxEditPeak = category.indexOf('EDIT_PEAK');
-    if (idxEditPeak >= 0) {
-      const sEP = jcamp.spectra[idxEditPeak];
-      const thresRef = calcThresRef(sEP, peakUp);
-      nfs.editPeak = buildPeakFeature(jcamp, layout, peakUp, sEP, thresRef);
-    }
-    const idxAutoPeak = category.indexOf('AUTO_PEAK');
-    if (idxAutoPeak >= 0) {
-      const sAP = jcamp.spectra[idxAutoPeak];
-      const thresRef = calcThresRef(sAP, peakUp);
-      nfs.autoPeak = buildPeakFeature(jcamp, layout, peakUp, sAP, thresRef);
-    }
-    nfs.integration = buildIntegFeature(jcamp, spectra);
-    nfs.multiplicity = buildMpyFeature(jcamp);
-    nfs.simulation = buildSimFeature(jcamp);
-    return nfs;
-  }
-
-  // workaround for legacy design
+  // jcamp.info.$CSCATEGORY is NOT reliably an array with one entry per
+  // jcamp.spectra[i] - jcampconverter's LDR parsing can leave it as a plain
+  // string (the label's raw storage key can differ subtly across otherwise
+  // equivalent LDR occurrences, e.g. across files merged from different
+  // sources), and even when it IS an array, using .indexOf() on it to index
+  // into the unrelated jcamp.spectra array only works by coincidence when
+  // the two arrays happen to line up 1:1. Instead, identify each spectrum's
+  // role from its own dataType via isPeakTable(), which is self-contained
+  // and works regardless of $CSCATEGORY's shape or block count/order.
   const features = jcamp.spectra.map(s => {
     const thresRef = calcThresRef(s, peakUp);
     return isPeakTable(s) ? buildPeakFeature(jcamp, layout, peakUp, s, thresRef) : null;

--- a/dist/helpers/extractParams.js
+++ b/dist/helpers/extractParams.js
@@ -31,7 +31,10 @@ const extractSharedParams = (entity, thresholdState, scanIdx = 0) => {
   } = entity || {};
   const autoPeak = features.autoPeak || features[scanIdx] || features[0] || {};
   const editPeak = features.editPeak || features[scanIdx] || features[0] || {};
-  const hasEdit = !!editPeak?.data?.[0]?.x?.length;
+  // A saved-but-empty EDIT_PEAK block (e.g. after "Clear All Peaks") must still
+  // count as an edit, or it gets treated as if no edit ever existed and the
+  // untouched auto-detected peaks resurface on reload.
+  const hasEdit = features.editPeak != null || !!editPeak?.data?.[0]?.x?.length;
   const feature = hasEdit && thresholdState?.isEdit ? editPeak : autoPeak;
   const {
     integration,

--- a/dist/reducers/reducer_shift.js
+++ b/dist/reducers/reducer_shift.js
@@ -51,7 +51,7 @@ const resetRef = payload => {
 const resetEnable = payload => {
   const {
     typ
-  } = payload.operation;
+  } = payload.operation || {};
   switch (typ) {
     case 'NMR':
       return true;

--- a/dist/sagas/index.js
+++ b/dist/sagas/index.js
@@ -12,6 +12,13 @@ var _saga_ui = _interopRequireDefault(require("./saga_ui"));
 var _saga_meta = _interopRequireDefault(require("./saga_meta"));
 var _saga_multiplicity = _interopRequireDefault(require("./saga_multiplicity"));
 var _saga_multi_entities = _interopRequireDefault(require("./saga_multi_entities"));
+const watchers = [..._saga_edit_peak.default, ..._saga_manager.default, ..._saga_ui.default, ..._saga_meta.default, ..._saga_multiplicity.default, ..._saga_multi_entities.default];
 function* rootSaga() {
-  yield (0, _effects.all)([..._saga_edit_peak.default, ..._saga_manager.default, ..._saga_ui.default, ..._saga_meta.default, ..._saga_multiplicity.default, ..._saga_multi_entities.default]);
+  // Each watcher gets its own spawn so an uncaught error in one (e.g. a
+  // malformed action payload reaching a single reducer/saga) only kills
+  // that watcher, instead of propagating up through `all` and cancelling
+  // every other watcher in the app for the rest of the session.
+  yield (0, _effects.all)(watchers.map(watcher => (0, _effects.spawn)(function* isolate() {
+    yield watcher;
+  })));
 }

--- a/src/__tests__/units/actions/lcms.test.tsx
+++ b/src/__tests__/units/actions/lcms.test.tsx
@@ -147,6 +147,24 @@ describe('LCMS ExtractJcamp', () => {
     expect(getLcMsInfo(entity).kind).toEqual('uvvis');
   });
 
+  it('Extract UVVIS keeps a saved-but-empty edit-peak table over the auto one (issue #329)', () => {
+    // Page 210's EDIT_PEAK block below genuinely has 3 rows in the fixture;
+    // emptying it here mimics reloading a file after "Clear All Peaks" was
+    // saved, while its sibling AUTO_PEAK block (11 rows) is left untouched.
+    const editPeakTableWithData = '##NPOINTS=0\n##PEAKTABLE= (XY..XY)\n594.86279296875, 150.07945251464844;\n599.2625122070312, 227.96824645996094;\n199.68751525878906, 415.1648254394531;\n##END=';
+    const emptiedEditPeakTable = '##NPOINTS=0\n##PEAKTABLE= (XY..XY)\n##END=';
+    expect(hplcMsUvvisJcamp.split(editPeakTableWithData).length - 1).toEqual(1);
+
+    const withEdit: any = ExtractJcamp(hplcMsUvvisJcamp);
+    const page210WithEdit = withEdit.spectra.find((s: any) => s.pageValue === 210);
+    expect(page210WithEdit.peaks.length).toEqual(3);
+
+    const injected = hplcMsUvvisJcamp.replace(editPeakTableWithData, emptiedEditPeakTable);
+    const withEmptiedEdit: any = ExtractJcamp(injected);
+    const page210Emptied = withEmptiedEdit.spectra.find((s: any) => s.pageValue === 210);
+    expect(page210Emptied.peaks).toEqual([]);
+  });
+
   it('Extract UVVIS reads ##$CSLCMSMZPAGE from first CHEMSPECTRA UVVIS peak table block', () => {
     const injected = hplcMsUvvisJcamp.replace(
       '$$ === CHEMSPECTRA UVVIS PEAK TABLE ===\n',

--- a/src/__tests__/units/helpers/chem.test.tsx
+++ b/src/__tests__/units/helpers/chem.test.tsx
@@ -6,6 +6,7 @@ import {
   buildIntegFeature, convertThresEndPts,
 } from "../../../helpers/chem";
 import nmr1HJcamp from "../../fixtures/nmr1h_jcamp";
+import nmr13cJcamp from "../../fixtures/nmr13c_jcamp";
 import aifJcamp1 from "../../fixtures/aif_jcamp_1";
 import dlsIntensityJcamp from '../../fixtures/dls_intensity_jcamp';
 import { LIST_SHIFT_1H } from "../../../constants/list_shift";
@@ -768,6 +769,32 @@ describe('Test for chem helper', () => {
       const entity: any = ExtractJcamp(secondsTaggedMz);
       expect(entity.features[0].pageValue).toBeCloseTo(1.1228166666666666);
       expect(entity.features[1].pageValue).toBeCloseTo(1.1384333333333334);
+    });
+  })
+
+  // extrFeaturesNi used to pick editPeak/autoPeak by looking up
+  // jcamp.info.$CSCATEGORY.indexOf('EDIT_PEAK'/'AUTO_PEAK') and using that
+  // as an index into the UNRELATED jcamp.spectra array. That only worked by
+  // coincidence when the two arrays happened to line up 1:1 - an extra
+  // $CSCATEGORY LDR anywhere else in the file (e.g. on a non-spectrum
+  // section, as real multi-file/bagit archives can carry) desyncs them.
+  // See issue #329's blank-graph/NaN-MHz report for a real-world case.
+  describe('Test extrFeaturesNi editPeak/autoPeak assignment is position-based, not $CSCATEGORY-index-based (issue #329)', () => {
+    it('still assigns editPeak/autoPeak to their own PEAKTABLE blocks when an extra $CSCATEGORY LDR desyncs the two arrays', () => {
+      const injected = nmr13cJcamp.replace('##BLOCKS=1', '##BLOCKS=1\n##$CSCATEGORY=SOMETHING_ELSE');
+      expect(injected).not.toEqual(nmr13cJcamp);
+
+      const entity: any = ExtractJcamp(injected);
+      const { editPeak, autoPeak } = entity.features;
+
+      expect(editPeak).toBeDefined();
+      expect(autoPeak).toBeDefined();
+      // EDIT_PEAK block's own ##PEAKTABLE= starts at x=-11.045182110091531;
+      // AUTO_PEAK's own starts at x=104.69281295027619 (see nmr13c_jcamp.js).
+      // A desynced index would either swap these or run off the end of
+      // jcamp.spectra entirely.
+      expect(editPeak.data[0].x[0]).toBeCloseTo(-11.045182110091531);
+      expect(autoPeak.data[0].x[0]).toBeCloseTo(104.69281295027619);
     });
   })
 })

--- a/src/__tests__/units/helpers/extractParams.test.tsx
+++ b/src/__tests__/units/helpers/extractParams.test.tsx
@@ -47,6 +47,34 @@ describe('Test extract parameters helper', () => {
       expect(params.hasEdit).toEqual(true);
     });
 
+    it('keeps a saved-but-empty edit table instead of resurrecting auto peaks (issue #329)', () => {
+      const clearedEntity = {
+        layout: LIST_LAYOUT.MS,
+        features: {
+          autoPeak: {
+            scanAutoTarget: 1,
+            data: [{ x: [1, 2], y: [10, 20] }],
+            origin: 'auto',
+          },
+          editPeak: {
+            scanEditTarget: 1,
+            data: [{ x: [], y: [] }],
+            origin: 'edit',
+          },
+        },
+        spectra: [{ data: [{ x: [100], y: [1000] }] }],
+      };
+
+      const params: any = extractParams(
+        clearedEntity as any,
+        { isEdit: true } as any,
+        { target: 1, isAuto: false } as any,
+      );
+      expect(params.hasEdit).toEqual(true);
+      expect(params.feature.origin).toEqual('edit');
+      expect(params.feature.data[0].x).toEqual([]);
+    });
+
     it('supports forceLcms option even on MS layout', () => {
       const params: any = extractParams(
         msEntity as any,

--- a/src/__tests__/units/reducers/reducer_shift.test.tsx
+++ b/src/__tests__/units/reducers/reducer_shift.test.tsx
@@ -1,0 +1,40 @@
+import shiftReducer from "../../../reducers/reducer_shift";
+import { MANAGER } from "../../../constants/action_type";
+
+describe('Test redux reducer for shift', () => {
+  it('Reset shift does not throw when payload.operation is missing (issue #329)', () => {
+    const state = {
+      selectedIdx: 0,
+      shifts: [{ ref: false, peak: false, enable: true }],
+    };
+    const action = {
+      type: MANAGER.RESETSHIFT,
+      payload: {
+        layout: '13C',
+        curvesInfo: { isMultiCurve: false, curveIdx: 0, numberOfCurve: 0 },
+      },
+    };
+
+    expect(() => shiftReducer(state, action)).not.toThrow();
+    const newState: any = shiftReducer(state, action);
+    expect(newState.shifts[0].enable).toEqual(false);
+  });
+
+  it('Reset shift enables NMR shift when payload.operation.typ is NMR', () => {
+    const state = {
+      selectedIdx: 0,
+      shifts: [{ ref: false, peak: false, enable: false }],
+    };
+    const action = {
+      type: MANAGER.RESETSHIFT,
+      payload: {
+        layout: '13C',
+        operation: { typ: 'NMR' },
+        curvesInfo: { isMultiCurve: false, curveIdx: 0, numberOfCurve: 0 },
+      },
+    };
+
+    const newState: any = shiftReducer(state, action);
+    expect(newState.shifts[0].enable).toEqual(true);
+  });
+})

--- a/src/__tests__/units/sagas/saga_isolation.test.tsx
+++ b/src/__tests__/units/sagas/saga_isolation.test.tsx
@@ -1,0 +1,64 @@
+import { createStore, applyMiddleware } from 'redux';
+import createSagaMiddleware from 'redux-saga';
+
+import { CURVE, MANAGER } from '../../../constants/action_type';
+import { ExtractJcamp } from '../../../helpers/chem';
+import nmr1HJcamp from '../../fixtures/nmr1h_jcamp';
+
+// A crash in one saga watcher must not cancel the other unrelated watchers
+// for the rest of the session - see issue #329 (reducer_shift.js's
+// resetEnable threw on an entity with no `operation` on its feature, which
+// took down the entire root saga since `all([...watchers])` propagates a
+// child task's uncaught error to every sibling).
+jest.mock('../../../reducers/reducer_shift', () => {
+  const actual = jest.requireActual('../../../reducers/reducer_shift');
+  return {
+    __esModule: true,
+    default: (state: any, action: any) => {
+      if (action.type === 'RESET_SHIFT' && action.payload && action.payload.__forceThrow) {
+        throw new Error('synthetic saga-isolation test crash');
+      }
+      return actual.default(state, action);
+    },
+  };
+});
+
+// eslint-disable-next-line import/first, import/newline-after-import
+import rootReducer from '../../../reducers/index';
+// eslint-disable-next-line import/first
+import rootSaga from '../../../sagas/index';
+
+const buildStore = () => {
+  const sagaMiddleware = createSagaMiddleware();
+  const store = createStore(
+    rootReducer,
+    applyMiddleware(sagaMiddleware),
+  );
+  sagaMiddleware.run(rootSaga);
+  return store;
+};
+
+describe('rootSaga watcher isolation (issue #329)', () => {
+  it('one watcher throwing does not stop other watchers from working', () => {
+    const store = buildStore();
+
+    // Trigger the crashing watcher: saga_manager.js's resetShift is watched
+    // via takeEvery(MANAGER.RESETALL, resetShift), which forwards payload
+    // through to a RESET_SHIFT dispatch - our mocked reducer throws on it.
+    expect(() => {
+      store.dispatch({ type: MANAGER.RESETALL, payload: { __forceThrow: true } });
+    }).not.toThrow();
+
+    // A completely unrelated watcher (saga_multi_entities.js's
+    // setInitIntegrations, watching CURVE.SET_ALL_CURVES) must still work
+    // after the above crash.
+    const entity: any = ExtractJcamp(nmr1HJcamp);
+    expect(entity.features.integration).toBeTruthy();
+
+    store.dispatch({ type: CURVE.SET_ALL_CURVES, payload: [entity] });
+
+    const state: any = store.getState();
+    expect(state.curve.listCurves.length).toEqual(1);
+    expect(state.integration.present.integrations[0]).toEqual(entity.features.integration);
+  });
+});

--- a/src/helpers/chem.js
+++ b/src/helpers/chem.js
@@ -984,28 +984,15 @@ const isPeakTable = (s) => (
 );
 
 const extrFeaturesNi = (jcamp, layout, peakUp, spectra) => {
-  const nfs = {};
-  const category = jcamp.info.$CSCATEGORY;
-  if (category) {
-    const idxEditPeak = category.indexOf('EDIT_PEAK');
-    if (idxEditPeak >= 0) {
-      const sEP = jcamp.spectra[idxEditPeak];
-      const thresRef = calcThresRef(sEP, peakUp);
-      nfs.editPeak = buildPeakFeature(jcamp, layout, peakUp, sEP, thresRef);
-    }
-    const idxAutoPeak = category.indexOf('AUTO_PEAK');
-    if (idxAutoPeak >= 0) {
-      const sAP = jcamp.spectra[idxAutoPeak];
-      const thresRef = calcThresRef(sAP, peakUp);
-      nfs.autoPeak = buildPeakFeature(jcamp, layout, peakUp, sAP, thresRef);
-    }
-    nfs.integration = buildIntegFeature(jcamp, spectra);
-    nfs.multiplicity = buildMpyFeature(jcamp);
-    nfs.simulation = buildSimFeature(jcamp);
-    return nfs;
-  }
-
-  // workaround for legacy design
+  // jcamp.info.$CSCATEGORY is NOT reliably an array with one entry per
+  // jcamp.spectra[i] - jcampconverter's LDR parsing can leave it as a plain
+  // string (the label's raw storage key can differ subtly across otherwise
+  // equivalent LDR occurrences, e.g. across files merged from different
+  // sources), and even when it IS an array, using .indexOf() on it to index
+  // into the unrelated jcamp.spectra array only works by coincidence when
+  // the two arrays happen to line up 1:1. Instead, identify each spectrum's
+  // role from its own dataType via isPeakTable(), which is self-contained
+  // and works regardless of $CSCATEGORY's shape or block count/order.
   const features = jcamp.spectra.map((s) => {
     const thresRef = calcThresRef(s, peakUp);
     return isPeakTable(s)

--- a/src/helpers/chem.js
+++ b/src/helpers/chem.js
@@ -596,14 +596,17 @@ const extrSpectraMs = (jcamp, layout) => {
       const pageKey = spectrum.pageValue ?? spectrum.page;
       const peakTable = peakTablesByPage.get(pageKey);
       let selectedPeakTable = null;
-      if (hasPeakData(peakTable?.edit)) {
+      // A saved-but-empty EDIT_PEAK table (e.g. after "Clear All Peaks") must
+      // still win over auto/other, or the deliberately-cleared peaks
+      // resurface as the untouched auto-detected ones on reload.
+      if (peakTable?.edit) {
         selectedPeakTable = peakTable.edit;
       } else if (hasPeakData(peakTable?.auto)) {
         selectedPeakTable = peakTable.auto;
       } else if (hasPeakData(peakTable?.other)) {
         selectedPeakTable = peakTable.other;
       } else {
-        selectedPeakTable = peakTable?.edit || peakTable?.auto || peakTable?.other || null;
+        selectedPeakTable = peakTable?.auto || peakTable?.other || null;
       }
 
       const normalizedData = needsSecToMin

--- a/src/helpers/extractParams.js
+++ b/src/helpers/extractParams.js
@@ -19,7 +19,10 @@ const extractSharedParams = (entity, thresholdState, scanIdx = 0) => {
   const { spectra = [], features = {} } = entity || {};
   const autoPeak = features.autoPeak || features[scanIdx] || features[0] || {};
   const editPeak = features.editPeak || features[scanIdx] || features[0] || {};
-  const hasEdit = !!editPeak?.data?.[0]?.x?.length;
+  // A saved-but-empty EDIT_PEAK block (e.g. after "Clear All Peaks") must still
+  // count as an edit, or it gets treated as if no edit ever existed and the
+  // untouched auto-detected peaks resurface on reload.
+  const hasEdit = features.editPeak != null || !!editPeak?.data?.[0]?.x?.length;
 
   const feature = hasEdit && thresholdState?.isEdit ? editPeak : autoPeak;
   const { integration, multiplicity } = features;

--- a/src/reducers/reducer_shift.js
+++ b/src/reducers/reducer_shift.js
@@ -54,7 +54,7 @@ const resetRef = (payload) => {
 };
 
 const resetEnable = (payload) => {
-  const { typ } = payload.operation;
+  const { typ } = payload.operation || {};
   switch (typ) {
     case 'NMR':
       return true;

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,4 +1,4 @@
-import { all } from 'redux-saga/effects';
+import { all, spawn } from 'redux-saga/effects';
 import editPeakSagas from './saga_edit_peak';
 import managerSagas from './saga_manager';
 import uiSagas from './saga_ui';
@@ -6,13 +6,21 @@ import metaSagas from './saga_meta';
 import multiplicitySagas from './saga_multiplicity';
 import multiEntitiesSagas from './saga_multi_entities';
 
+const watchers = [
+  ...editPeakSagas,
+  ...managerSagas,
+  ...uiSagas,
+  ...metaSagas,
+  ...multiplicitySagas,
+  ...multiEntitiesSagas,
+];
+
 export default function* rootSaga() {
-  yield all([
-    ...editPeakSagas,
-    ...managerSagas,
-    ...uiSagas,
-    ...metaSagas,
-    ...multiplicitySagas,
-    ...multiEntitiesSagas,
-  ]);
+  // Each watcher gets its own spawn so an uncaught error in one (e.g. a
+  // malformed action payload reaching a single reducer/saga) only kills
+  // that watcher, instead of propagating up through `all` and cancelling
+  // every other watcher in the app for the rest of the session.
+  yield all(watchers.map((watcher) => spawn(function* isolate() {
+    yield watcher;
+  })));
 }


### PR DESCRIPTION
## Why this is a draft

These four commits were originally on #330. They were split out when a review found that
two of them regress peak rendering. They are parked here rather than dropped: two are
ready as-is, two need rework before this can leave draft.

The test suite passes on this branch (758/85) — that is **not** evidence the regressions
are absent. It is the coverage gap: no existing test opens a never-edited spectrum, and
the LC/MS test asserts only page 210, the one page with a real edit.

## Ready as-is

- **`fix(shift): don't crash resetShift when a feature has no operation`** — `resetEnable`
  destructured `payload.operation` unguarded. Correct and self-contained.
- **`fix(sagas): isolate each root saga watcher`** — each watcher gets its own `spawn`, so
  one crash no longer cancels every other watcher. Correct for its stated goal. Two
  follow-ups worth folding in before merge: `spawn` detaches tasks from root-task
  cancellation, so each `sagaMiddleware.run(rootSaga)` in tests leaves the previous run's
  watchers alive (inert in `app.js`, where the store is a module singleton); and a crashed
  watcher is now silently dead for the session, so a `try`/`catch` with a `console.error`
  would keep the failure diagnosable.

## Needs rework

### `fix(peaks): don't resurrect auto-detected peaks for a saved-but-empty edit table`

The goal is right — a deliberately-cleared peak table must not come back as the
auto-detected one on reload — but `hasEdit = features.editPeak != null` cannot distinguish
*"an edit was saved and is empty"* from *"this file has a template EDIT_PEAK block"*.
`buildPeakFeature` returns a non-null object for any EDIT_PEAK block, and every
chemotion-written jcamp has one. With `reducer_threshold`'s `isEdit: true` default,
`feature = hasEdit && isEdit ? editPeak : autoPeak` resolves to the empty edit table.

- `emissions_jcamp.js` (EDIT_PEAK `NPOINTS=0`, AUTO_PEAK `NPOINTS=4`) renders 4 peaks on
  master and 0 with this commit.
- The `chem.js` half does the same to LC/MS UV/VIS: dropping the `hasPeakData` guard means
  pages 230/254/280/366/450/550/580 of `lc_ms_jcamp_uvvis.js` — each with a 0-point
  EDIT_PEAK beside AUTO_PEAK tables of 53/92/3/8/100/100/100 points — all render zero.
  Same for `lc_ms_jcamp_uvvis_chemstation.js` pages 254/300/400.
- It also flips `hasEdit` true for never-edited files, enabling the restore toggles in
  `r02_scan.js` / `r03_threshold.js` that should be disabled.

This needs a marker that distinguishes a written-back empty table from a template one, or
an explicit flag set at save time. The jcamp does not currently carry one, so this is a
format/design decision, not a code tweak.

### `fix(chem): stop extrFeaturesNi indexing spectra by a collapsed $CSCATEGORY string`

The bug being fixed is real: `$CSCATEGORY` is not reliably an array, and `.indexOf('EDIT_PEAK')`
on a *string* returns a character offset that then indexes `jcamp.spectra` nonsensically.

The replacement trades it for a stricter unchecked assumption — `editPeak: features[0],
autoPeak: features[1]` over the `isPeakTable`-filtered blocks, i.e. purely positional:

- A file with only an AUTO_PEAK table exposes it as `editPeak` with `autoPeak` undefined.
  `extractSharedParams` then resolves `autoPeak` to `{}`, so toggling to "Auto Picked"
  loses every peak.
- A file whose AUTO_PEAK block precedes EDIT_PEAK gets the two swapped outright.

All current fixtures happen to order SPECTRUM → EDIT_PEAK → AUTO_PEAK, so the common path
survives, but that ordering becomes load-bearing and untested. The added test is named
"assignment is position-based", which documents the assumption as intended behaviour.

**The fix is already in this file.** `chem.js:399` normalizes the LDR shape and `chem.js:420`
exposes a safe per-index accessor, which the MS path uses at `chem.js:582`:

```js
const csCategories = [].concat(jcamp?.info?.$CSCATEGORY || []).map((c) => String(c).toUpperCase());
const getCategory = (idx) => csCategories[idx] || '';
```

Reusing that in `extrFeaturesNi` keeps role identification by name, handles the
string-shaped `$CSCATEGORY`, and needs no positional assumption.

## Provenance

Authorship is `@headri`'s throughout (`cherry-pick -x`). The pre-split tip of #330,
`7b7449c`, is preserved at `refs/backup/pr-330-original`.
